### PR TITLE
fix: added media query to minimze padding for <768px

### DIFF
--- a/src/static/css/styles.css
+++ b/src/static/css/styles.css
@@ -313,6 +313,9 @@ h1 {
 }
 
 .item-input-group {
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
     display: flex;
     flex-direction: column;
 }


### PR DESCRIPTION
### **User description**
# What is this issue for and how does it solve it

Issue was the input boxes could go outside its parent container
I just added an extra media query to minimize the padding when the user is on a phone.
also fixed the items-row children max-width
i think this also makes the UI feel a bit less restrictive. 

# Link to the Github Issue
https://github.com/McMaster-Solar-Car-Project/purchase-request-site/issues/2
Before:
<img width="1041" height="831" alt="image" src="https://github.com/user-attachments/assets/09101529-cd86-4839-99e2-dcc519dc6766" />
After:
<img width="1041" height="831" alt="image" src="https://github.com/user-attachments/assets/57e96ced-934d-4e55-adf8-20290f81dc8b" />


___

### **PR Type**
Bug fix


___

### **Description**
- Reduces padding for mobile devices (< 768px)

- Prevents input boxes from overflowing parent container

- Improves mobile UI responsiveness and usability


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Mobile viewport<br/>&lt;768px"] -- "media query" --> B["Reduced padding<br/>0.5rem"]
  B --> C["Dashboard/Items/Form<br/>sections"]
  C --> D["Input boxes fit<br/>container"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>styles.css</strong><dd><code>Add mobile media query for reduced padding</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/static/css/styles.css

<ul><li>Added media query rule for screens under 768px width<br> <li> Applies reduced padding (0.5rem) to dashboard-section, items-section, <br>and form-accordion-content<br> <li> Prevents input elements from exceeding parent container boundaries on <br>mobile devices</ul>


</details>


  </td>
  <td><a href="https://github.com/McMaster-Solar-Car-Project/purchase-request-site/pull/144/files#diff-4a0d27cef4f43ddf00ff12ac276f9b96fdc60b569659dd4460348f663e095b87">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

