### PR TITLE
separate build and deploy stages

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     outputs:
-      image-tag: ${{ steps.meta.outputs.tags }}
+      image-tag: ${{ steps.tag.outputs.single-tag }}
       image-digest: ${{ steps.build.outputs.digest }}
     steps:
       - name: Checkout code
@@ -29,6 +29,14 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Generate single tag
+        id: tag
+        run: |
+          # Create a deterministic tag using commit SHA
+          SINGLE_TAG="${{ secrets.DOCKERHUB_USERNAME }}/purchase-request-site:main-${{ github.sha }}"
+          echo "single-tag=$SINGLE_TAG" >> $GITHUB_OUTPUT
+          echo "Generated single tag: $SINGLE_TAG"
 
       - name: Extract metadata
         id: meta
@@ -53,7 +61,8 @@ jobs:
 
       - name: Output image info
         run: |
-          echo "Image tags: ${{ steps.meta.outputs.tags }}"
+          echo "Single deployment tag: ${{ steps.tag.outputs.single-tag }}"
+          echo "All image tags: ${{ steps.meta.outputs.tags }}"
           echo "Image digest: ${{ steps.build.outputs.digest }}"
 
   deploy:


### PR DESCRIPTION
### **User description**
# What is this issue for and how does it solve it
separate things to make it easier to optimize certains steps

# Link to the Github Issue


___

### **PR Type**
Enhancement


___

### **Description**
- Separate build and deploy into independent workflow jobs

- Add workflow dispatch input to manually trigger deployments

- Export Docker image metadata from build job to deploy job

- Conditionally run deploy job based on branch and event type

- Replace hardcoded image tags with dynamic outputs from build


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Workflow Triggered<br/>push or dispatch"] --> B["Build Job<br/>Build & Push Image"]
  B --> C["Output Image Metadata<br/>tags & digest"]
  C --> D["Deploy Job<br/>Conditional Execution"]
  D --> E["Deploy to Server<br/>Using Image Outputs"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build-and-deploy.yml</strong><dd><code>Refactor workflow into separate build and deploy stages</code>&nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/build-and-deploy.yml

<ul><li>Split monolithic <code>build-and-deploy</code> job into separate <code>build</code> and <code>deploy</code> <br>jobs<br> <li> Added <code>workflow_dispatch</code> input parameter to allow manual deployment <br>triggering<br> <li> Build job now exports Docker image tags and digest as outputs for <br>deploy job consumption<br> <li> Deploy job conditionally executes only on main branch push or manual <br>dispatch with deploy flag<br> <li> Updated deployment script to use dynamic image outputs instead of <br>hardcoded image tags<br> <li> Added debug output step to display generated image information</ul>


</details>


  </td>
  <td><a href="https://github.com/McMaster-Solar-Car-Project/purchase-request-site/pull/158/files#diff-ecad2183af1362d9d99f4a33e7491c1970c92255c3c318e688ece549ec91fe33">+24/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

