### PR TITLE
added logger before db initialized for datetime

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -26,6 +26,9 @@ load_dotenv()
 # Set up logger
 logger = setup_logger(__name__)
 
+# Log start time and date
+logger.info(f"Started at {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+
 # Create required directories immediately (before mounting static files)
 required_dirs = ["sessions"]
 for directory in required_dirs:


### PR DESCRIPTION
### **User description**
# What is this issue for and how does it solve it
When the program first starts, and even before the database gets initialized, log the start date and time

# Link to the Github Issue
https://github.com/McMaster-Solar-Car-Project/purchase-request-site/issues/147


___

### **PR Type**
Enhancement


___

### **Description**
- Log application start timestamp before database initialization

- Captures startup time in human-readable format for debugging


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Application Start"] --> B["Setup Logger"]
  B --> C["Log Start Timestamp"]
  C --> D["Initialize Database"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Add startup timestamp logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main.py

<ul><li>Added logger call to record application start time and date<br> <li> Logs timestamp in 'YYYY-MM-DD HH:MM:SS' format using <code>datetime.now()</code><br> <li> Positioned before database initialization for early startup visibility</ul>


</details>


  </td>
  <td><a href="https://github.com/McMaster-Solar-Car-Project/purchase-request-site/pull/172/files#diff-2e5ad92c43aa96cc3a9cef6c6aec998b216f1379c43b1f651013d25e55989312">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

