### PR TITLE
Use GitHub-hosted Docker builders

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -20,12 +20,12 @@ env:
   RUN_LIVE_PIPELINE_TEST: ${{ vars.RUN_LIVE_PIPELINE_TEST }}
 jobs:
   build:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-      - name: Setup Blacksmith Builder
-        uses: useblacksmith/setup-docker-builder@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub
         uses: docker/login-action@v4
         with:
@@ -42,7 +42,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
       - name: Build and push Docker image
         id: build
-        uses: useblacksmith/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true

--- a/.github/workflows/docker-build-check.yml
+++ b/.github/workflows/docker-build-check.yml
@@ -4,11 +4,9 @@ on:
     branches: [main, master]
 jobs:
   docker-build-check:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo in .venv
         uses: actions/checkout@v4
-      - name: Setup Blacksmith Builder
-        uses: useblacksmith/setup-docker-builder@v1
       - name: Build Docker image
         run: docker build -t purchase-request-site:${{ github.sha }} .


### PR DESCRIPTION
## Summary
- switch Docker build jobs from Blacksmith runners to GitHub-hosted Ubuntu runners
- replace Blacksmith Docker builder/action usage with Docker's official Buildx/build-push actions
- use the default Docker builder for the PR Docker image build check

## Verification
- grep confirmed no Blacksmith references remain in .github/workflows
- git diff --check
- uv run ruff check