### PR TITLE
ci: make production deploys manual

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,14 +1,7 @@
 name: Build and Deploy to Production
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
-    inputs:
-      deploy:
-        description: 'Deploy to production'
-        required: false
-        default: 'false'
-        type: boolean
+run-name: Deploy ${{ github.sha }} to production
 env:
   DEBUG: ${{ vars.DEBUG }}
   ENVIRONMENT: ${{ vars.ENVIRONMENT }}
@@ -22,6 +15,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Validate deploy branch
+        run: |
+          if [ "$GITHUB_REF" != "refs/heads/main" ]; then
+            echo "This workflow must be run from the main branch."
+            exit 1
+          fi
       - name: Checkout code
         uses: actions/checkout@v6
       - name: Set up Docker Buildx
@@ -58,7 +57,6 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: build
-    if: github.event_name == 'pull_request' || (github.ref == 'refs/heads/main' && (github.event_name == 'push' || inputs.deploy == true))
     steps:
       - name: Deploy to server
         uses: appleboy/ssh-action@v1.0.3


### PR DESCRIPTION
# What is this issue for and how does it solve it
Makes production deploys an explicit manual GitHub Actions workflow instead of deploying automatically on pushes to `main`.

The deploy workflow now:
- only runs from the GitHub Actions manual trigger
- fails fast if someone tries to run it from a branch other than `main`
- keeps the existing Docker build/push and SSH deploy behavior

# Link to the Github Issue
N/A

# Validation
- `uv run ruff check --fix`
- `uv run ruff format`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/build-and-deploy.yml"); puts "YAML parsed"'`
- `docker run --rm -v "$PWD:/workspace" ghcr.io/google/yamlfmt:latest -lint /workspace/.github/workflows/build-and-deploy.yml`
