### PR TITLE
Move app startup work into lifespan

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,7 +1,8 @@
 import logging
 import os
 import secrets
-from collections.abc import Mapping
+from collections.abc import AsyncIterator, Mapping
+from contextlib import asynccontextmanager
 from datetime import datetime
 from typing import cast
 from urllib.parse import urlparse
@@ -32,7 +33,6 @@ from src.routers.utils import AuthRedirect, limiter, templates
 # Set up logger
 logger = setup_logger(__name__)
 HEALTH_PATH_PREFIX = "/health"
-settings = get_settings()
 
 
 def _event_is_for_health_endpoint(event: Mapping[str, object]) -> bool:
@@ -113,65 +113,37 @@ def configure_uvicorn_access_log_filter() -> None:
         access_logger.addFilter(ExcludeUnwantedAccessLogsFilter())
 
 
-# Log start time and date
-logger.info(f"Started at {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+def configure_sentry() -> None:
+    """Configure Sentry integrations for the running app."""
+    settings = get_settings()
+    sentry_sdk.init(
+        dsn=settings.sentry_dsn,
+        integrations=[
+            FastApiIntegration(),
+            SqlalchemyIntegration(),
+            # Disable legacy breadcrumb/event behavior; native Sentry logs are enabled.
+            LoggingIntegration(event_level=None, level=None),
+        ],
+        enable_logs=True,
+        environment=settings.environment,
+        release=settings.sentry_release,
+        traces_sample_rate=1.0,
+        profile_session_sample_rate=1.0,
+        profile_lifecycle="trace",
+        before_send=_drop_unwanted_sentry_payload,
+        before_send_transaction=_drop_unwanted_sentry_payload,
+    )
 
-# Create required directories immediately (before mounting static files)
-required_dirs = ["sessions"]
-for directory in required_dirs:
-    os.makedirs(directory, exist_ok=True)
 
-
-sentry_sdk.init(
-    dsn=settings.sentry_dsn,
-    integrations=[
-        FastApiIntegration(),
-        SqlalchemyIntegration(),
-        # Disable legacy breadcrumb/event behavior - we use native Sentry logs via sentry_sdk.logger
-        LoggingIntegration(event_level=None, level=None),
-    ],
-    enable_logs=True,  # Enable Sentry's native structured logs
-    environment=settings.environment,
-    release=settings.sentry_release,
-    traces_sample_rate=1.0,
-    profile_session_sample_rate=1.0,
-    profile_lifecycle="trace",
-    before_send=_drop_unwanted_sentry_payload,
-    before_send_transaction=_drop_unwanted_sentry_payload,
-)
-
-configure_uvicorn_access_log_filter()
-
-init_database()
-app = FastAPI(
-    title="Purchase Request Site",
-    docs_url=None if settings.is_production else "/docs",
-    redoc_url=None if settings.is_production else "/redoc",
-    openapi_url=None if settings.is_production else "/openapi.json",
-)
-
-# Add request logging middleware
-app.add_middleware(RequestLoggingMiddleware)
-
-# Generate a random secret key for this session (Note: users will be logged out on restart)
-session_secret = secrets.token_urlsafe(32)
-
-# Add session middleware for authentication
-app.add_middleware(
-    SessionMiddleware,
-    secret_key=session_secret,
-)
-
-# Mount static files (directories are guaranteed to exist now)
-app.mount("/static", StaticFiles(directory="src/static"), name="static")
-app.mount("/sessions", StaticFiles(directory="sessions"), name="sessions")
-
-# Include routers
-app.include_router(auth_router)
-app.include_router(dashboard_router)
-app.include_router(profile_router)
-app.include_router(success_router)
-app.include_router(download_router)
+@asynccontextmanager
+async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
+    """Run app startup/shutdown work outside module import."""
+    logger.info(f"Started at {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+    os.makedirs("sessions", exist_ok=True)
+    configure_sentry()
+    configure_uvicorn_access_log_filter()
+    init_database()
+    yield
 
 
 async def handle_exceed_limit(request: Request, exc: Exception):
@@ -181,31 +153,26 @@ async def handle_exceed_limit(request: Request, exc: Exception):
     return RedirectResponse(url="/login?error=ratelimit", status_code=303)
 
 
-# Initialize rate limiter
-app.state.limiter = limiter
-app.add_exception_handler(RateLimitExceeded, handle_exceed_limit)
-
-
-@app.get("/")
 async def home():
     """Redirect home page to login"""
     return RedirectResponse(url="/login", status_code=303)
 
 
-@app.get("/health")
 async def health_check():
     """Health check endpoint for Docker health monitoring"""
     return {"status": "healthy", "timestamp": datetime.now().isoformat()}
 
 
-@app.exception_handler(AuthRedirect)
-async def auth_redirect_handler(request: Request, exc: AuthRedirect):
+async def auth_redirect_handler(request: Request, exc: Exception):
     """Redirect unauthenticated requests to the login page (or other target)."""
+    if not isinstance(exc, AuthRedirect):
+        raise exc
     return RedirectResponse(url=exc.location, status_code=303)
 
 
-@app.exception_handler(StarletteHTTPException)
-async def http_exception_handler(request: Request, exc: StarletteHTTPException):
+async def http_exception_handler(request: Request, exc: Exception):
+    if not isinstance(exc, StarletteHTTPException):
+        raise exc
     if exc.status_code == 404:
         return templates.TemplateResponse(
             request=request,
@@ -221,7 +188,6 @@ async def http_exception_handler(request: Request, exc: StarletteHTTPException):
     )
 
 
-@app.exception_handler(Exception)
 async def generic_exception_handler(request: Request, exc: Exception):
     if request.url.path.startswith(HEALTH_PATH_PREFIX):
         return JSONResponse(status_code=500, content={"status": "unhealthy"})
@@ -234,9 +200,50 @@ async def generic_exception_handler(request: Request, exc: Exception):
     )
 
 
+def create_app() -> FastAPI:
+    """Create and configure the FastAPI application."""
+    settings = get_settings()
+    application = FastAPI(
+        title="Purchase Request Site",
+        docs_url=None if settings.is_production else "/docs",
+        redoc_url=None if settings.is_production else "/redoc",
+        openapi_url=None if settings.is_production else "/openapi.json",
+        lifespan=lifespan,
+    )
+
+    application.add_middleware(RequestLoggingMiddleware)
+
+    # Generate a random secret key for this process; users are logged out on restart.
+    session_secret = secrets.token_urlsafe(32)
+    application.add_middleware(SessionMiddleware, secret_key=session_secret)
+
+    application.mount("/static", StaticFiles(directory="src/static"), name="static")
+
+    application.include_router(auth_router)
+    application.include_router(dashboard_router)
+    application.include_router(profile_router)
+    application.include_router(success_router)
+    application.include_router(download_router)
+
+    application.state.limiter = limiter
+    application.add_exception_handler(RateLimitExceeded, handle_exceed_limit)
+    application.add_exception_handler(AuthRedirect, auth_redirect_handler)
+    application.add_exception_handler(StarletteHTTPException, http_exception_handler)
+    application.add_exception_handler(Exception, generic_exception_handler)
+
+    application.add_api_route("/", home, methods=["GET"])
+    application.add_api_route("/health", health_check, methods=["GET"])
+
+    return application
+
+
+app = create_app()
+
+
 if __name__ == "__main__":
     import uvicorn
 
+    settings = get_settings()
     logger.info(f"Starting server at {datetime.now().isoformat()}")
     uvicorn.run(
         app,

--- a/tests/api/test_app_routes.py
+++ b/tests/api/test_app_routes.py
@@ -1,0 +1,9 @@
+from src.main import create_app
+
+
+def test_sessions_directory_is_not_mounted() -> None:
+    app = create_app()
+
+    mounted_paths = {getattr(route, "path", "") for route in app.routes}
+
+    assert "/sessions" not in mounted_paths


### PR DESCRIPTION
## Summary
- Reapply the lifespan/app-factory work that was reverted from the stacked branch
- Move Sentry setup, access-log filtering, sessions directory creation, and database initialization out of module import
- Keep `/sessions` private by not mounting it as static files
- Add a route-surface regression test for the removed `/sessions` mount

## Notes
This replaces the accidentally removed/reverted lifespan PR. The base stack branch has also been updated with the merged Ruff/uv hotfix so CI can run cleanly.

## Tests
- `uv run ruff check`
- `uv run ruff format --check`
- `uv run ty check`
- `uv run pytest`
