### PR TITLE
Apply amber UI redesign without CI/CD changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,15 +8,1165 @@
       "name": "purchase-request-site",
       "version": "0.1.0",
       "devDependencies": {
+        "@tailwindcss/cli": "^4.0.0",
         "tailwindcss": "^4.0.0"
       }
     },
-    "node_modules/tailwindcss": {
-      "version": "4.1.16",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.16.tgz",
-      "integrity": "sha512-pONL5awpaQX4LN5eiv7moSiSPd/DLDzKVRJz8Q9PgzmAdd1R4307GQS2ZpfiN7ZmekdQrfhZZiSE5jkLR4WNaA==",
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@parcel/watcher": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz",
+      "integrity": "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^1.0.3",
+        "is-glob": "^4.0.3",
+        "micromatch": "^4.0.5",
+        "node-addon-api": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher-android-arm64": "2.5.1",
+        "@parcel/watcher-darwin-arm64": "2.5.1",
+        "@parcel/watcher-darwin-x64": "2.5.1",
+        "@parcel/watcher-freebsd-x64": "2.5.1",
+        "@parcel/watcher-linux-arm-glibc": "2.5.1",
+        "@parcel/watcher-linux-arm-musl": "2.5.1",
+        "@parcel/watcher-linux-arm64-glibc": "2.5.1",
+        "@parcel/watcher-linux-arm64-musl": "2.5.1",
+        "@parcel/watcher-linux-x64-glibc": "2.5.1",
+        "@parcel/watcher-linux-x64-musl": "2.5.1",
+        "@parcel/watcher-win32-arm64": "2.5.1",
+        "@parcel/watcher-win32-ia32": "2.5.1",
+        "@parcel/watcher-win32-x64": "2.5.1"
+      }
+    },
+    "node_modules/@parcel/watcher-android-arm64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.1.tgz",
+      "integrity": "sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-arm64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.1.tgz",
+      "integrity": "sha512-eAzPv5osDmZyBhou8PoF4i6RQXAfeKL9tjb3QzYuccXFMQU0ruIc/POh30ePnaOyD1UXdlKguHBmsTs53tVoPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-x64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.1.tgz",
+      "integrity": "sha512-1ZXDthrnNmwv10A0/3AJNZ9JGlzrF82i3gNQcWOzd7nJ8aj+ILyW1MTxVk35Db0u91oD5Nlk9MBiujMlwmeXZg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-freebsd-x64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.1.tgz",
+      "integrity": "sha512-SI4eljM7Flp9yPuKi8W0ird8TI/JK6CSxju3NojVI6BjHsTyK7zxA9urjVjEKJ5MBYC+bLmMcbAWlZ+rFkLpJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-glibc": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.1.tgz",
+      "integrity": "sha512-RCdZlEyTs8geyBkkcnPWvtXLY44BCeZKmGYRtSgtwwnHR4dxfHRG3gR99XdMEdQ7KeiDdasJwwvNSF5jKtDwdA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-musl": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.1.tgz",
+      "integrity": "sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-glibc": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.1.tgz",
+      "integrity": "sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-musl": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.1.tgz",
+      "integrity": "sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-glibc": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.1.tgz",
+      "integrity": "sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-musl": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.1.tgz",
+      "integrity": "sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-arm64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.1.tgz",
+      "integrity": "sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-ia32": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.1.tgz",
+      "integrity": "sha512-c2KkcVN+NJmuA7CGlaGD1qJh1cLfDnQsHjE89E60vUEMlqduHGCdCLJCID5geFVM0dOtA3ZiIO8BoEQmzQVfpQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-x64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.1.tgz",
+      "integrity": "sha512-9lHBdJITeNR++EvSQVUcaZoWupyHfXe1jZvGZ06O/5MflPcuPLtEphScIBL+AiCWBO46tDSHzWyD0uDmmZqsgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tailwindcss/cli": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/cli/-/cli-4.3.1.tgz",
+      "integrity": "sha512-ZWPy20rF+TBfTImxDMG3Wr75Y3RpaPlo9lc+oJbInlMyjT+XPkTVKVIL5RZ7JirXuIahcfHoLNFRmDorKi+JQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@parcel/watcher": "2.5.1",
+        "@tailwindcss/node": "4.3.1",
+        "@tailwindcss/oxide": "4.3.1",
+        "enhanced-resolve": "5.21.6",
+        "mri": "^1.2.0",
+        "picocolors": "^1.1.1",
+        "tailwindcss": "4.3.1"
+      },
+      "bin": {
+        "tailwindcss": "dist/index.mjs"
+      }
+    },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.1.tgz",
+      "integrity": "sha512-6NDaqRoAMSXD1mr/RXu0HBvNE9a2n5tHPsxu9XHLws8o4Twes5rBM2205SUUiJ9goAtadrN6xTGX0UDEwp/N4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "5.21.6",
+        "jiti": "^2.7.0",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.3.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.1.tgz",
+      "integrity": "sha512-yVPyo8RNkabVr3O2EhHEE0Rewu7YKzc1DhIqfL46LKveFrmu9XbDazNOJY7/GRuvw1h6u3utWnR29H/p5JPlgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.3.1",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.1",
+        "@tailwindcss/oxide-darwin-x64": "4.3.1",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.1",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.1",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.1",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.1",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.1",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.1",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.1",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.1",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.1.tgz",
+      "integrity": "sha512-SVlyf61g374l5cHyg8x9kf5xmLcOaxvOTsbsqDnSsDJaKOEFZ7GCvi84VAVGpxojYOs1+3K6M0UjXfqPU8vmOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.1.tgz",
+      "integrity": "sha512-hVnWLwv+e/l7c4WKyVtHVrIPvYdqWHjRB3MDIqARynzFtnQg85kmQEFCbV9Ja0VVx4xXTIiDWY60Y7iz/iNoDA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.1.tgz",
+      "integrity": "sha512-Cf7abu0WVgbhU7ANgPUnSAvm7nCvMweusHb8FnaHlLfv/Caq4GYaEZg7ZImzzmjx4lIAfuS8q+eLIS7A7IzxIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.1.tgz",
+      "integrity": "sha512-ZZqzX2Y+GXtXXfqSfpJhDm60OoZfvLHLCgm+J7NVqgHHJjG/m9ugZI77RwTsVd4fnBJuCFP6Ae6kTJb71UdS8g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.1.tgz",
+      "integrity": "sha512-/Ah/xik0LaMYfv9DZ0S/t4pBlBNYOcqtRwusjgovHkvT8ixueWCLyJjsaF5kQIckjb4IT8Q6K6p/iPmZMixYgg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.1.tgz",
+      "integrity": "sha512-gqdFoVJlw444GvpnheZLHmvTzSxI/cOUUh2KSNejQjTcYkW062SVD+En0rUgD+QV91bz1XGIGtt1HJd48xUGbQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.1.tgz",
+      "integrity": "sha512-Bwv9KwOvE0VKa86xPFif9b9c3Y1NxOV1P0gLti/IYaWEsQYZXDlxfGEtA8mdDZ7SG3wyNXAWYT5SIn3giL57oA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.1.tgz",
+      "integrity": "sha512-Ymi8O8T15HYQdOUWUtTI6ldN0neHP85FC+Qz32xTcZ7iJXtem/x8ITev0o1e9e5rkqj4lONZfTRLvkmin1+tKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.1.tgz",
+      "integrity": "sha512-M+P/91qJ6uILLw4k2G93GMDRAXj61SMvFQYt39AqvUqYgExXpLL5aepfns7sj4HiAQeolirQF9E0lzRvdf4zPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.1.tgz",
+      "integrity": "sha512-zsM8uOeqvVGHsAXsJxsT28ttosFahLJKCLOTUBqRAtKnVgGSRitds9T432QiT8b77Yga7JIBkulIRRlJPtYhRA==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.10.0",
+        "@emnapi/runtime": "^1.10.0",
+        "@emnapi/wasi-threads": "^1.2.1",
+        "@napi-rs/wasm-runtime": "^1.1.4",
+        "@tybys/wasm-util": "^0.10.2",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.1.tgz",
+      "integrity": "sha512-aiNvSq9BsVk8V513lDKlrCFAgf8qBMPZTpgEhInL+NwQqs97mYmupVMrPrgBBSL8Pv/0zXu9MrMF9rMun1ZeNg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.1.tgz",
+      "integrity": "sha512-xDEyu1rg290472FEGaKHnzyDyh5QH+AlWvsU5hMoMtPpzmKlRI0jaYKCgSHDYtaQWZOYbMaduSyCwFwY4n1HmA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "detect-libc": "bin/detect-libc.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.21.6",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.6.tgz",
+      "integrity": "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss/node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.1.tgz",
+      "integrity": "sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
     }
   }
 }

--- a/src/routers/dashboard.py
+++ b/src/routers/dashboard.py
@@ -224,7 +224,7 @@ def dashboard(
             "Please check the highlighted purchase request details and try again."
         )
     elif updated:
-        success_message = "Your profile has been updated successfully!"
+        success_message = "Your profile has been updated successfully."
 
     profile_is_complete = is_user_profile_complete(user)
     if profile_incomplete or not profile_is_complete:

--- a/src/static/css/input.css
+++ b/src/static/css/input.css
@@ -4,3 +4,883 @@
 /* Content paths are specified in tailwind.config.js */
 @source "./templates/**/*.html";
 @source "./static/js/**/*.js";
+
+:root {
+  --font-display: "Archivo", "Bricolage Grotesque", sans-serif;
+  --font-body: "Public Sans", "Bricolage Grotesque", sans-serif;
+  --font-mono: "IBM Plex Mono", monospace;
+  --page-bg: #10110f;
+  --surface: rgba(24, 25, 23, 0.94);
+  --surface-strong: #1e211d;
+  --surface-soft: #282b26;
+  --surface-quiet: rgba(0, 0, 0, 0.16);
+  --ink: #f8f2dc;
+  --muted: #c6bfa9;
+  --subtle: #8f876f;
+  --line: rgba(248, 242, 220, 0.18);
+  --line-strong: rgba(248, 242, 220, 0.34);
+  --accent: #f2b84b;
+  --accent-strong: #d99625;
+  --accent-cool: #56d6d0;
+  --danger: #ff7661;
+  --success: #73d99d;
+  --warning: #f2b84b;
+  --field-bg: rgba(255, 255, 255, 0.07);
+  --field-border: rgba(248, 242, 220, 0.2);
+  --radius: 8px;
+  --radius-sm: 6px;
+  --shadow: 0 22px 60px rgba(0, 0, 0, 0.3);
+}
+
+input[type="number"]::-webkit-outer-spin-button,
+input[type="number"]::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+input[type="number"] {
+  -moz-appearance: textfield;
+  appearance: textfield;
+}
+
+.app-page,
+.app-page * {
+  box-sizing: border-box;
+  letter-spacing: 0;
+}
+
+.app-page {
+  min-height: 100vh;
+  margin: 0;
+  overflow-x: hidden;
+  background:
+    repeating-linear-gradient(90deg, rgba(255, 255, 255, 0.04) 0 1px, transparent 1px 70px),
+    repeating-linear-gradient(0deg, rgba(255, 255, 255, 0.035) 0 1px, transparent 1px 70px),
+    linear-gradient(135deg, rgba(242, 184, 75, 0.08), transparent 38%, rgba(81, 211, 199, 0.08)),
+    var(--page-bg);
+  color: var(--ink);
+  font-family: var(--font-body);
+  line-height: 1.45;
+}
+
+.app-page a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.app-page button,
+.app-page input,
+.app-page select,
+.app-page textarea {
+  font: inherit;
+}
+
+.app-shell {
+  width: min(94vw, 1500px);
+  margin: 0 auto;
+  padding: 42px 0 64px;
+}
+
+.narrow-shell {
+  width: min(92vw, 980px);
+}
+
+.auth-page,
+.status-page {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: 28px 0;
+}
+
+.auth-shell,
+.status-shell {
+  width: min(92vw, 500px);
+}
+
+.status-shell {
+  width: min(92vw, 820px);
+}
+
+.app-card,
+.profile-panel,
+.workflow-panel,
+.invoice-card {
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--surface);
+  box-shadow: var(--shadow);
+}
+
+.auth-card,
+.status-card,
+.form-card {
+  padding: 1.15rem;
+}
+
+.brand-lockup {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  margin-bottom: 1rem;
+}
+
+.brand-mark {
+  display: grid;
+  width: 46px;
+  height: 46px;
+  place-items: center;
+  border: 1px solid var(--accent);
+  border-radius: var(--radius-sm);
+  background: rgba(242, 184, 75, 0.14);
+  color: var(--accent);
+  font-family: var(--font-mono);
+  font-weight: 800;
+}
+
+.eyebrow,
+.section-kicker,
+.panel-kicker,
+.invoice-kicker {
+  margin: 0 0 0.55rem;
+  color: var(--accent);
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+h4,
+.header-copy h1,
+.section-heading h2,
+.profile-panel h2,
+.invoice-header h3,
+.panel-heading h4 {
+  margin: 0;
+  color: var(--ink);
+  font-family: var(--font-display);
+  font-weight: 800;
+  line-height: 1;
+}
+
+.auth-card h1,
+.status-card h1 {
+  font-size: clamp(2.4rem, 8vw, 4rem);
+}
+
+.dashboard-header h1,
+.page-header h1 {
+  max-width: 980px;
+  font-size: clamp(2.5rem, 6vw, 4.7rem);
+}
+
+.section-heading h2 {
+  font-size: clamp(1.8rem, 3vw, 2.6rem);
+}
+
+.subtitle,
+.dashboard-help,
+.profile-panel p,
+.profile-note p,
+.field-help,
+.items-help,
+.submit-note,
+.muted-copy,
+.card-footer,
+.request-panel p {
+  color: var(--muted);
+}
+
+.subtitle {
+  max-width: 720px;
+  margin: 0.75rem 0 0;
+  font-size: 1rem;
+}
+
+.dashboard-header,
+.page-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 1rem;
+  align-items: end;
+  margin-bottom: 1.1rem;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: linear-gradient(90deg, rgba(242, 184, 75, 0.12), rgba(81, 211, 199, 0.06));
+  padding: 1rem;
+}
+
+.page-header {
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: start;
+}
+
+.action-bar,
+.form-actions,
+.status-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.6rem;
+}
+
+.button {
+  display: inline-flex;
+  min-height: 42px;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  border: 1px solid var(--button-line, var(--line-strong));
+  border-radius: var(--radius-sm);
+  background: var(--button-bg, transparent);
+  color: var(--button-ink, var(--ink));
+  cursor: pointer;
+  font-weight: 800;
+  line-height: 1;
+  padding: 0.75rem 1rem;
+  text-align: center;
+  transition:
+    background-color 180ms ease,
+    border-color 180ms ease,
+    color 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.button:hover,
+.button:focus-visible {
+  transform: translateY(-1px);
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(242, 184, 75, 0.2);
+}
+
+.button:disabled {
+  cursor: not-allowed;
+  opacity: 0.52;
+  transform: none;
+}
+
+.button--primary {
+  --button-bg: var(--accent);
+  --button-ink: #11110d;
+  --button-line: var(--accent);
+}
+
+.button--secondary {
+  --button-bg: rgba(255, 255, 255, 0.03);
+  --button-ink: var(--ink);
+}
+
+.button--danger,
+.button--remove {
+  --button-bg: transparent;
+  --button-ink: var(--danger);
+  --button-line: color-mix(in srgb, var(--danger), transparent 45%);
+}
+
+.button--clear {
+  min-height: 44px;
+  color: var(--muted);
+  padding: 0 0.95rem;
+}
+
+.button--remove {
+  min-width: 78px;
+  padding-inline: 0.7rem;
+}
+
+.button--full {
+  width: 100%;
+}
+
+.notice {
+  margin: 0 0 1rem;
+  border: 1px solid var(--notice-line, var(--line));
+  border-radius: var(--radius);
+  background: var(--notice-bg, var(--surface));
+  color: var(--notice-ink, var(--ink));
+  padding: 0.9rem 1rem;
+  font-weight: 800;
+}
+
+.notice a {
+  color: inherit;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.notice--success {
+  --notice-bg: color-mix(in srgb, var(--success), transparent 86%);
+  --notice-line: color-mix(in srgb, var(--success), transparent 52%);
+  --notice-ink: var(--success);
+}
+
+.notice--error {
+  --notice-bg: color-mix(in srgb, var(--danger), transparent 86%);
+  --notice-line: color-mix(in srgb, var(--danger), transparent 52%);
+  --notice-ink: var(--danger);
+}
+
+.notice--warning {
+  --notice-bg: color-mix(in srgb, var(--warning), transparent 88%);
+  --notice-line: color-mix(in srgb, var(--warning), transparent 48%);
+  --notice-ink: var(--warning);
+}
+
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: minmax(260px, 320px) minmax(0, 1fr);
+  gap: 1rem;
+  align-items: start;
+}
+
+.profile-panel {
+  position: sticky;
+  top: 16px;
+  border-left: 5px solid var(--accent);
+  padding: 1rem;
+}
+
+.profile-panel__top {
+  border-bottom: 1px solid var(--line);
+  padding-bottom: 1rem;
+}
+
+.profile-panel__top h2 {
+  font-size: 1.75rem;
+}
+
+.profile-panel__top > p:not(.panel-kicker) {
+  margin: 0.35rem 0 0;
+}
+
+.meta-row span {
+  display: block;
+  color: var(--subtle);
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.requester-email {
+  overflow-wrap: anywhere;
+}
+
+.profile-note {
+  margin-top: 1rem;
+  padding-top: 0;
+}
+
+.profile-note p {
+  margin: 0;
+  font-size: 0.92rem;
+}
+
+.workflow-panel {
+  padding: 1rem;
+}
+
+.section-heading {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 1rem;
+  border-bottom: 1px solid var(--line);
+  margin-bottom: 1rem;
+  padding: 0.25rem 0 1rem;
+}
+
+.dashboard-help {
+  max-width: 310px;
+  margin: 0;
+  text-align: right;
+}
+
+.forms-stack,
+.form-stack {
+  display: grid;
+  gap: 0.95rem;
+}
+
+.invoice-card {
+  overflow: hidden;
+  border-left: 5px solid transparent;
+  background: var(--surface-strong);
+}
+
+.invoice-card:hover {
+  border-left-color: var(--accent-cool);
+}
+
+.invoice-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  min-height: 74px;
+  cursor: pointer;
+  padding: 0.95rem 1rem;
+}
+
+.invoice-header h3 {
+  font-size: 1.15rem;
+}
+
+.invoice-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+}
+
+.invoice-actions .button--clear,
+.invoice-actions .toggle-glyph {
+  width: 76px;
+  min-width: 76px;
+  min-height: 44px;
+}
+
+.toggle-glyph {
+  display: grid;
+  width: 76px;
+  height: 44px;
+  place-items: center;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-sm);
+  color: var(--accent);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-weight: 800;
+  transition:
+    background-color 180ms ease,
+    border-color 180ms ease,
+    box-shadow 180ms ease,
+    transform 180ms ease;
+}
+
+.invoice-header:hover .toggle-glyph,
+.toggle-glyph:hover,
+.toggle-glyph:focus-visible {
+  border-color: var(--accent);
+  background: color-mix(in srgb, var(--accent), transparent 86%);
+  box-shadow: 0 0 0 3px rgba(242, 184, 75, 0.16);
+  transform: translateY(-1px);
+}
+
+.invoice-content {
+  border-top: 1px solid var(--line);
+  padding: 1rem;
+}
+
+.reimbursement-form {
+  display: grid;
+  gap: 1rem;
+}
+
+.form-grid,
+.invoice-grid,
+.upload-grid,
+.financial-grid,
+.document-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.field,
+.item-input-group {
+  min-width: 0;
+}
+
+.field--full {
+  grid-column: 1 / -1;
+}
+
+.field-label {
+  display: block;
+  margin-bottom: 0.42rem;
+  color: var(--ink);
+  font-size: 0.82rem;
+  font-weight: 800;
+}
+
+.required-mark {
+  color: var(--danger);
+}
+
+.field-control {
+  display: block;
+  width: 100%;
+  min-height: 44px;
+  border: 1px solid var(--field-border);
+  border-radius: var(--radius-sm);
+  background: var(--field-bg);
+  color: var(--ink);
+  outline: none;
+  padding: 0.72rem 0.8rem;
+  transition:
+    border-color 160ms ease,
+    background-color 160ms ease,
+    box-shadow 160ms ease;
+}
+
+.field-control::placeholder {
+  color: var(--subtle);
+}
+
+.field-control:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent), transparent 72%);
+}
+
+.field-control[readonly],
+.total-field {
+  background: color-mix(in srgb, var(--surface-soft), black 10%);
+  color: var(--ink);
+}
+
+.text-area {
+  min-height: 118px;
+  resize: vertical;
+}
+
+.field-help,
+.file-name,
+.items-help {
+  display: block;
+  margin-top: 0.4rem;
+  color: var(--muted);
+  font-size: 0.76rem;
+}
+
+.custom-file-upload {
+  min-width: 0;
+}
+
+.upload-zone {
+  position: relative;
+  display: grid;
+  min-height: 96px;
+  place-items: center;
+  border: 1px dashed var(--line-strong);
+  border-radius: var(--radius-sm);
+  background: var(--field-bg);
+  padding: 1rem;
+  text-align: center;
+  transition:
+    border-color 160ms ease,
+    background-color 160ms ease,
+    transform 160ms ease;
+}
+
+.upload-zone.is-dragging,
+.upload-zone:hover {
+  border-color: var(--accent);
+  background: color-mix(in srgb, var(--accent), transparent 88%);
+}
+
+.file-input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.drop-text {
+  margin: 0;
+}
+
+.file-upload {
+  color: var(--accent);
+  cursor: pointer;
+  font-weight: 800;
+}
+
+.file-name {
+  color: var(--subtle);
+  overflow-wrap: anywhere;
+}
+
+.request-panel,
+.document-panel {
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--surface-quiet);
+  padding: 1rem;
+}
+
+.panel-heading {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.panel-heading h4,
+.request-panel h2 {
+  font-size: 1rem;
+}
+
+.items-container {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.item-row {
+  display: grid;
+  grid-template-columns: 1.25fr 1.25fr 0.52fr 0.8fr 0.8fr auto;
+  gap: 0.75rem;
+  align-items: end;
+  min-width: 0;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.05);
+  padding: 0.85rem;
+}
+
+.item-actions {
+  display: flex;
+  align-items: end;
+}
+
+.total-row {
+  margin-top: 1rem;
+}
+
+.total-output {
+  min-height: 52px;
+  border-color: var(--accent);
+  font-size: 1.05rem;
+  font-weight: 800;
+}
+
+.dashboard-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 1rem;
+  border-top: 1px solid var(--line);
+  margin-top: 1.2rem;
+  padding-top: 1.2rem;
+}
+
+.submit-note {
+  margin: 0;
+  font-weight: 800;
+}
+
+.form-card {
+  display: grid;
+  gap: 1.2rem;
+}
+
+.profile-upload-zone {
+  position: relative;
+  display: grid;
+  min-height: 112px;
+  place-items: center;
+  border: 1px dashed var(--line-strong);
+  border-radius: var(--radius-sm);
+  background: var(--field-bg);
+  padding: 1rem;
+  text-align: center;
+}
+
+.profile-upload-zone span {
+  color: var(--accent);
+  font-weight: 800;
+}
+
+.profile-upload-zone small {
+  color: var(--muted);
+}
+
+.file-input-overlay {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  cursor: pointer;
+  opacity: 0;
+}
+
+.document-preview {
+  margin-top: 0.85rem;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.05);
+  padding: 0.75rem;
+}
+
+.document-preview img {
+  display: block;
+  max-width: 100%;
+  max-height: 150px;
+  border-radius: var(--radius-sm);
+}
+
+.document-preview object {
+  width: 100%;
+  height: 270px;
+  border-radius: var(--radius-sm);
+}
+
+.muted-copy {
+  margin: 0.7rem 0 0;
+  font-size: 0.9rem;
+}
+
+.highlight-panel {
+  border-color: color-mix(in srgb, var(--accent), transparent 45%);
+  background: color-mix(in srgb, var(--accent), transparent 90%);
+}
+
+.highlight-panel strong {
+  color: var(--ink);
+}
+
+.status-card {
+  display: grid;
+  gap: 1rem;
+}
+
+.status-list {
+  display: grid;
+  gap: 0.6rem;
+  margin: 0.8rem 0 0;
+  padding-left: 1.1rem;
+  color: var(--muted);
+}
+
+.status-list strong {
+  color: var(--ink);
+}
+
+.meta-row {
+  display: grid;
+  gap: 0.25rem;
+  margin: 0.9rem 0;
+}
+
+.card-footer {
+  border-top: 1px solid var(--line);
+  margin-top: 1rem;
+  padding-top: 1rem;
+  font-size: 0.9rem;
+}
+
+.card-footer p {
+  margin: 0;
+}
+
+.card-footer p + p {
+  margin-top: 0.45rem;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .dashboard-header,
+  .page-header,
+  .notice,
+  .profile-panel,
+  .workflow-panel,
+  .app-card {
+    animation: rise-in 420ms ease both;
+  }
+
+  .workflow-panel {
+    animation-delay: 80ms;
+  }
+}
+
+@keyframes rise-in {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 1200px) {
+  .dashboard-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .profile-panel {
+    position: static;
+  }
+
+  .item-row {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .item-actions {
+    align-items: stretch;
+  }
+}
+
+@media (max-width: 860px) {
+  .app-shell {
+    width: min(94vw, 1500px);
+    padding: 24px 0 44px;
+  }
+
+  .dashboard-header,
+  .page-header {
+    grid-template-columns: 1fr;
+  }
+
+  .page-header .button {
+    width: fit-content;
+  }
+
+  .action-bar,
+  .dashboard-help {
+    justify-content: flex-start;
+    text-align: left;
+  }
+
+  .section-heading,
+  .panel-heading {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .form-grid,
+  .invoice-grid,
+  .upload-grid,
+  .financial-grid,
+  .document-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .workflow-panel,
+  .profile-panel,
+  .invoice-content,
+  .invoice-header {
+    padding: 0.85rem;
+  }
+
+  .invoice-header {
+    align-items: flex-start;
+  }
+
+  .item-row {
+    grid-template-columns: 1fr;
+  }
+
+  .button--primary,
+  .dashboard-actions .button {
+    width: 100%;
+    min-width: 0;
+  }
+}

--- a/src/static/js/dashboard.js
+++ b/src/static/js/dashboard.js
@@ -117,10 +117,10 @@ function toggleForm(formNumber) {
 
     if (content.style.display === 'none' || content.style.display === '') {
         content.style.display = 'block';
-        toggle.textContent = '▲';
+        toggle.textContent = '-';
     } else {
         content.style.display = 'none';
-        toggle.textContent = '▼';
+        toggle.textContent = '+';
     }
 }
 
@@ -303,7 +303,7 @@ function updateCurrencyLabels(formNumber) {
         }
 
         if (cadBreakdown) cadBreakdown.style.display = 'none';
-        if (usdBreakdown) usdBreakdown.style.display = 'block';
+        if (usdBreakdown) usdBreakdown.style.display = 'grid';
 
         if (totalInput) {
             totalInput.removeAttribute('readonly');
@@ -323,7 +323,7 @@ function updateCurrencyLabels(formNumber) {
         const currentSubtotal = parseMoneyCents(subtotalInput ? subtotalInput.value : '');
         updateHstRequirement(formNumber, currentSubtotal);
 
-        if (cadBreakdown) cadBreakdown.style.display = 'block';
+        if (cadBreakdown) cadBreakdown.style.display = 'grid';
         if (usdBreakdown) usdBreakdown.style.display = 'none';
 
         if (totalInput) totalInput.setAttribute('readonly', '');
@@ -343,11 +343,7 @@ function updateCurrencyLabels(formNumber) {
         const proofOfPaymentInput = document.getElementById(`proof_of_payment_${formNumber}`);
         if (proofOfPaymentInput) {
             proofOfPaymentInput.required = false;
-            proofOfPaymentInput.value = '';
-            const filenameSpan = document.getElementById(`payment-filename-${formNumber}`);
-            if (filenameSpan) {
-                filenameSpan.textContent = 'No file chosen';
-            }
+            resetFileInput(proofOfPaymentInput, `payment-filename-${formNumber}`);
         }
     }
 }
@@ -357,6 +353,8 @@ function updateFileName(input, spanId) {
     const dropArea = input.closest('[data-role="file-drop-area"]');
     const dropTextSpan = dropArea ? dropArea.querySelector('[data-role="file-upload-text"]') : null;
 
+    if (!filenameSpan) return;
+
     if (input.files && input.files[0]) {
         const name = input.files[0].name;
         filenameSpan.textContent = name;
@@ -365,6 +363,12 @@ function updateFileName(input, spanId) {
         filenameSpan.textContent = 'No file chosen';
         if (dropTextSpan) dropTextSpan.innerHTML = '<b>Choose a file</b> or drag it here';
     }
+}
+
+function resetFileInput(input, spanId) {
+    if (!input) return;
+    input.value = '';
+    updateFileName(input, spanId);
 }
 
 function validateSubmission() {
@@ -502,19 +506,9 @@ function clearForm(formNumber) {
 
     const invoiceFileInput = document.getElementById(`invoice_file_${formNumber}`);
     const proofOfPaymentInput = document.getElementById(`proof_of_payment_${formNumber}`);
-    const invoiceFilenameSpan = document.getElementById(`invoice-filename-${formNumber}`);
-    const paymentFilenameSpan = document.getElementById(`payment-filename-${formNumber}`);
 
-    if (invoiceFileInput) {
-        invoiceFileInput.value = '';
-        invoiceFileInput.files = null;
-    }
-    if (proofOfPaymentInput) {
-        proofOfPaymentInput.value = '';
-        proofOfPaymentInput.files = null;
-    }
-    if (invoiceFilenameSpan) invoiceFilenameSpan.textContent = 'No file chosen';
-    if (paymentFilenameSpan) paymentFilenameSpan.textContent = 'No file chosen';
+    resetFileInput(invoiceFileInput, `invoice-filename-${formNumber}`);
+    resetFileInput(proofOfPaymentInput, `payment-filename-${formNumber}`);
 
     const itemsContainer = document.getElementById(`items-container-${formNumber}`);
     if (itemsContainer) {
@@ -564,16 +558,16 @@ function clearForm(formNumber) {
 
 function handleDragOver(event) {
     event.preventDefault();
-    event.currentTarget.classList.add('border-indigo-400', 'bg-indigo-500/10');
+    event.currentTarget.classList.add('is-dragging');
 }
 
 function handleDragLeave(event) {
-    event.currentTarget.classList.remove('border-indigo-400', 'bg-indigo-500/10');
+    event.currentTarget.classList.remove('is-dragging');
 }
 
 function handleFileDrop(event, inputId, spanId) {
     event.preventDefault();
-    event.currentTarget.classList.remove('border-indigo-400', 'bg-indigo-500/10');
+    event.currentTarget.classList.remove('is-dragging');
 
     const fileInput = document.getElementById(inputId);
     const files = event.dataTransfer.files;
@@ -667,6 +661,10 @@ document.addEventListener('DOMContentLoaded', function () {
 
     const form = document.querySelector('form[action="/submit-all-requests"]');
     const submitBtn = document.getElementById("submit-all-btn");
+
+    if (!form || !submitBtn) {
+        return;
+    }
 
     form.addEventListener("submit", (e) => {
         if (!profileIsComplete) {

--- a/src/static/js/edit-profile.js
+++ b/src/static/js/edit-profile.js
@@ -91,18 +91,6 @@ document.addEventListener('DOMContentLoaded', function () {
     showUrlErrorAlerts();
 
     const form = document.querySelector('form');
-    const backLink = document.getElementById('back-link');
-
-    if (backLink) {
-        backLink.addEventListener('click', function (e) {
-            if (!validateDefault()) {
-                e.preventDefault();
-                e.stopPropagation();
-                return false;
-            }
-            return true;
-        });
-    }
 
     if (form) {
         form.addEventListener('submit', function (e) {

--- a/src/templates/404.html
+++ b/src/templates/404.html
@@ -5,15 +5,23 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>404 - Page Not Found</title>
-  <link rel="stylesheet" href="/static/css/output.css">
+  <link rel="stylesheet" href="/static/css/output.css?v=amber-ui">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;800&family=Bricolage+Grotesque:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600;700&family=Public+Sans:wght@400;500;600;700;800&display=swap" rel="stylesheet">
 </head>
 
-<body class="m-0 min-h-screen bg-zinc-950 text-zinc-100 flex items-center justify-center px-6 font-sans">
-  <div class="w-full max-w-2xl rounded-2xl border border-zinc-800 bg-zinc-900/80 p-8 text-center shadow-xl">
-    <h1 class="m-0 text-3xl font-semibold tracking-tight text-white md:text-4xl">404 - Page Not Found</h1>
-    <p class="mt-4 text-base text-zinc-300 md:text-lg">The page you are looking for doesn't exist or the URL might be incorrect.</p>
-    <p class="mt-6 text-sm text-zinc-400"><strong class="text-zinc-200">Need Help?</strong> Please contact Raj on Teams.</p>
-  </div>
+<body class="app-page status-page">
+  <main class="app-shell status-shell">
+    <section class="app-card status-card">
+      <p class="eyebrow">404</p>
+      <h1>Page Not Found</h1>
+      <p class="subtitle">The page you are looking for does not exist or the URL might be incorrect.</p>
+      <footer class="card-footer">
+        <p><strong>Need help?</strong> Please contact Raj on Teams.</p>
+      </footer>
+    </section>
+  </main>
 </body>
 
 </html>

--- a/src/templates/_invoice_form.html
+++ b/src/templates/_invoice_form.html
@@ -1,0 +1,166 @@
+{% macro item_row(form_num, item_num) -%}
+<div class="item-row">
+    <div class="item-input-group">
+        <label class="field-label">Item Name</label>
+        <input type="text" name="item_name_{{ form_num }}_{{ item_num }}" placeholder="Enter item name" class="field-control">
+    </div>
+    <div class="item-input-group">
+        <label class="field-label">Usage/Purpose</label>
+        <input type="text" name="item_usage_{{ form_num }}_{{ item_num }}" placeholder="What is this item for?" class="field-control">
+    </div>
+    <div class="item-input-group">
+        <label class="field-label">Quantity</label>
+        <input type="number" name="item_quantity_{{ form_num }}_{{ item_num }}" min="1" value="1" data-action="calc-item" data-form="{{ form_num }}" data-item="{{ item_num }}" class="field-control">
+    </div>
+    <div class="item-input-group">
+        <label class="field-label">Item Cost (<span class="currency-label-{{ form_num }}">CAD</span>)</label>
+        <input type="number" name="item_price_{{ form_num }}_{{ item_num }}" min="0" step="0.00000001" placeholder="0.00" data-action="calc-item" data-form="{{ form_num }}" data-item="{{ item_num }}" class="field-control">
+    </div>
+    <div class="item-input-group">
+        <label class="field-label">Total</label>
+        <input type="number" name="item_total_{{ form_num }}_{{ item_num }}" readonly placeholder="0.00" class="field-control total-field">
+    </div>
+    <div class="item-actions">
+        <button type="button" class="button button--remove btn-remove" data-action="remove-item" data-form="{{ form_num }}" style="display: none;">Remove</button>
+    </div>
+</div>
+{%- endmacro %}
+
+{% macro upload_field(form_num, field_name, label, filename_id, help_text, required_text="") -%}
+<div class="form-group field">
+    <label for="{{ field_name }}_{{ form_num }}" class="field-label">{{ label }}{{ required_text }}</label>
+    <div class="custom-file-upload">
+        <div class="file-drop-area upload-zone" data-role="file-drop-area" data-input-id="{{ field_name }}_{{ form_num }}" data-filename-id="{{ filename_id }}-{{ form_num }}">
+            <input type="file" id="{{ field_name }}_{{ form_num }}" name="{{ field_name }}_{{ form_num }}" accept=".pdf,.jpg,.jpeg,.png,.gif" data-filename-id="{{ filename_id }}-{{ form_num }}" class="file-input">
+            <p class="drop-text">
+                <span class="file-upload" data-role="file-upload-text" data-input-id="{{ field_name }}_{{ form_num }}">
+                    <b>Choose a file</b> or drag it here
+                </span>
+            </p>
+        </div>
+        <span class="file-name" id="{{ filename_id }}-{{ form_num }}">No file chosen</span>
+    </div>
+    <small class="field-help file-help">{{ help_text }}</small>
+</div>
+{%- endmacro %}
+
+{% macro invoice_form(form_num) -%}
+    <div class="invoice-card form-accordion" data-form="{{ form_num }}">
+    <div class="invoice-header form-accordion-header" data-action="toggle-form" data-form="{{ form_num }}">
+        <div>
+            <h3>Invoice {{ form_num }}</h3>
+        </div>
+        <div class="form-header-actions invoice-actions">
+            <button type="button" class="button button--clear btn-clear" data-action="clear-form" data-form="{{ form_num }}" title="Clear this form">Clear</button>
+            <span class="form-toggle toggle-glyph" data-role="accordion-toggle">+</span>
+        </div>
+    </div>
+    <div class="invoice-content form-accordion-content" id="form-{{ form_num }}">
+        <div class="reimbursement-form">
+            <div class="invoice-grid">
+                <div class="form-group field">
+                    <label for="vendor_name_{{ form_num }}" class="field-label">Vendor/Store Name</label>
+                    <input type="text" id="vendor_name_{{ form_num }}" name="vendor_name_{{ form_num }}" placeholder="Enter the vendor or store" class="field-control">
+                </div>
+
+                <div class="form-group field">
+                    <label for="currency_{{ form_num }}" class="field-label">Currency</label>
+                    <select id="currency_{{ form_num }}" name="currency_{{ form_num }}" data-action="currency-select" data-form="{{ form_num }}" class="field-control">
+                        <option value="CAD">CAD - Canadian Dollar</option>
+                        <option value="USD">USD - US Dollar</option>
+                    </select>
+                    <small class="field-help file-help">Select the currency used for this purchase</small>
+                </div>
+            </div>
+
+            <div class="upload-grid">
+                {{ upload_field(form_num, "invoice_file", "Upload Invoice/Receipt", "invoice-filename", "Please upload your invoice or receipt as PDF, JPG, PNG, or GIF.") }}
+
+                <div class="proof-of-payment-section proof-of-payment-section-{{ form_num }}" style="display: none;">
+                    {{ upload_field(form_num, "proof_of_payment", "Proof of Payment", "payment-filename", "Required for USD purchases. Upload a bank transaction or payment confirmation.") }}
+                </div>
+            </div>
+
+            <div class="request-panel items-section">
+                <div class="panel-heading">
+                    <div>
+                        <h4>Item Details</h4>
+                        <small class="items-help">Add the items you purchased, up to 15 items.</small>
+                    </div>
+                    <button type="button" class="button button--secondary btn-secondary" data-action="add-item" data-form="{{ form_num }}">Add Item</button>
+                </div>
+
+                <div id="items-container-{{ form_num }}" class="items-container">
+                    {{ item_row(form_num, 1) }}
+                </div>
+            </div>
+
+            <div class="request-panel total-section">
+                <div class="panel-heading">
+                    <h4>Financial Summary</h4>
+                </div>
+
+                <div class="financial-breakdown cad-breakdown-{{ form_num }} financial-grid">
+                    <div class="form-row">
+                        <div class="form-group field">
+                            <label for="subtotal_amount_{{ form_num }}" class="field-label">Subtotal (<span class="currency-label-{{ form_num }}">CAD</span>)</label>
+                            <input type="number" id="subtotal_amount_{{ form_num }}" name="subtotal_amount_{{ form_num }}" readonly min="0" step="0.00000001" placeholder="0.00" class="field-control total-field">
+                            <small class="field-help financial-help">Calculated from item totals</small>
+                        </div>
+                    </div>
+
+                    <div class="form-row">
+                        <div class="form-group field">
+                            <label for="discount_amount_{{ form_num }}" class="field-label">Discount (<span class="currency-label-{{ form_num }}">CAD</span>)</label>
+                            <input type="number" id="discount_amount_{{ form_num }}" name="discount_amount_{{ form_num }}" min="0" step="0.00000001" placeholder="0.00" data-action="recalc-total" data-form="{{ form_num }}" class="field-control">
+                            <small class="field-help financial-help">Coupons, discounts, or rebates</small>
+                        </div>
+                    </div>
+
+                    <div class="form-row">
+                        <div class="form-group field">
+                            <label for="hst_gst_amount_{{ form_num }}" class="field-label"><span class="tax-label-{{ form_num }}">HST/GST</span> (<span class="currency-label-{{ form_num }}">CAD</span>) <span class="required-indicator-{{ form_num }}"></span></label>
+                            <input type="number" id="hst_gst_amount_{{ form_num }}" name="hst_gst_amount_{{ form_num }}" min="0" step="0.00000001" placeholder="0.00" data-action="recalc-total" data-form="{{ form_num }}" class="field-control">
+                            <small class="field-help financial-help tax-help-{{ form_num }}">Harmonized Sales Tax / Goods and Services Tax</small>
+                        </div>
+                    </div>
+
+                    <div class="form-row">
+                        <div class="form-group field">
+                            <label for="shipping_amount_{{ form_num }}" class="field-label">Shipping and Handling (<span class="currency-label-{{ form_num }}">CAD</span>)</label>
+                            <input type="number" id="shipping_amount_{{ form_num }}" name="shipping_amount_{{ form_num }}" min="0" step="0.00000001" placeholder="0.00" data-action="recalc-total" data-form="{{ form_num }}" class="field-control">
+                            <small class="field-help financial-help">Shipping, delivery, and handling fees</small>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="financial-breakdown usd-breakdown-{{ form_num }} financial-grid" style="display: none;">
+                    <div class="form-row">
+                        <div class="form-group field">
+                            <label for="us_subtotal_{{ form_num }}" class="field-label">US Subtotal (USD)</label>
+                            <input type="number" id="us_subtotal_{{ form_num }}" name="us_subtotal_{{ form_num }}" readonly min="0" step="0.00000001" placeholder="0.00" class="field-control total-field">
+                            <small class="field-help financial-help">Calculated from item costs</small>
+                        </div>
+                    </div>
+
+                    <div class="form-row">
+                        <div class="form-group field">
+                            <label for="us_additional_fees_{{ form_num }}" class="field-label">Additional Fees (USD)</label>
+                            <input type="number" id="us_additional_fees_{{ form_num }}" name="us_additional_fees_{{ form_num }}" min="0" step="0.00000001" placeholder="0.00" class="field-control">
+                            <small class="field-help financial-help">Taxes, tariffs, shipping, or other fees</small>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="form-row total-row">
+                    <div class="form-group field">
+                        <label for="total_cad_amount_{{ form_num }}" class="field-label"><span class="total-label-{{ form_num }}">Total Reimbursement Amount</span> (CAD)</label>
+                        <input type="number" id="total_cad_amount_{{ form_num }}" name="total_cad_amount_{{ form_num }}" readonly min="0" step="0.00000001" placeholder="0.00" class="field-control total-field total-output">
+                        <small class="field-help financial-help total-help-{{ form_num }}">Calculated as subtotal minus discount plus tax and shipping</small>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{%- endmacro %}

--- a/src/templates/dashboard.html
+++ b/src/templates/dashboard.html
@@ -1,355 +1,98 @@
+{% from "_invoice_form.html" import invoice_form, item_row %}
 <!DOCTYPE html>
 <html lang="en">
 
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Purchase Request Dashboard</title>
-    <link rel="stylesheet" href="/static/css/output.css">
+    <title>{{ title }}</title>
+    <link rel="stylesheet" href="/static/css/output.css?v=amber-ui">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;800&family=Bricolage+Grotesque:wght@400;500;600;700;800&family=Fraunces:opsz,wght@9..144,500..800&family=IBM+Plex+Mono:wght@400;500;600;700&family=Literata:opsz,wght@7..72,400..700&family=Public+Sans:wght@400;500;600;700;800&display=swap" rel="stylesheet">
     {% include "_sentry.html" %}
-    <style>
-    /* Remove number input spinner/step buttons */
-    input[type="number"]::-webkit-outer-spin-button,
-    input[type="number"]::-webkit-inner-spin-button {
-      -webkit-appearance: none;
-      margin: 0;
-    }
-
-    input[type="number"] {
-      -moz-appearance: textfield;
-      appearance: textfield;
-    }
-  </style>
 </head>
 
-<body class="font-['Inter',-apple-system,BlinkMacSystemFont,sans-serif] m-0 py-10 bg-[#0a0a0c] bg-[radial-gradient(circle_at_50%_0%,#1a1a22_0%,#0a0a0c_70%)] min-h-screen text-zinc-200">
-    <div class="dashboard-container max-w-7xl w-[95%] mx-auto bg-[rgba(24,24,27,0.84)] border border-[rgba(255,255,255,0.08)] rounded-2xl shadow-[0_8px_32px_rgba(0,0,0,0.28)] p-8 md:p-10">
-        <div class="dashboard-header flex flex-col gap-4 md:flex-row md:items-center md:justify-between mb-6">
-            <h1 class="m-0 text-3xl md:text-4xl font-semibold tracking-tight text-white">Purchase Request Dashboard</h1>
-            <div class="dashboard-user-info flex items-center gap-3">
-                <a href="/edit-profile" class="edit-profile-btn inline-flex items-center rounded-lg border border-[rgba(99,102,241,0.45)] px-3 py-2 text-sm text-[#c4b5fd] hover:bg-[rgba(99,102,241,0.15)] transition-colors">✏️ Edit Information</a>
-                <a href="/logout" class="logout-btn inline-flex items-center rounded-lg border border-[rgba(239,68,68,0.45)] px-3 py-2 text-sm text-red-300 hover:bg-[rgba(239,68,68,0.18)] transition-colors">Logout</a>
+<body class="app-page dashboard-page">
+    <div class="app-shell dashboard-shell">
+        <header class="dashboard-header">
+            <div class="header-copy">
+                <h1>Purchase Request Dashboard</h1>
+                <p class="subtitle">Fill out up to 10 purchase requests and submit them together.</p>
             </div>
-        </div>
+
+            <div class="dashboard-user-info action-bar">
+                <a href="/edit-profile" class="button button--secondary edit-profile-btn">Edit Information</a>
+                <a href="/logout" class="button button--danger logout-btn">Logout</a>
+            </div>
+        </header>
 
         {% if success_message %}
-        <div class="dashboard-success-message rounded-lg border border-emerald-500/40 bg-emerald-500/10 px-4 py-3 mb-4 text-emerald-200">
+        <div class="notice dashboard-success-message notice--success">
             {{ success_message }}
         </div>
         {% endif %}
 
         {% if error_message %}
-        <div class="error-message rounded-lg border border-red-500/40 bg-red-500/10 px-4 py-3 mb-4 text-red-200">
+        <div class="notice error-message notice--error">
             {{ error_message }}
         </div>
         {% endif %}
 
         {% if profile_warning_message %}
-        <div class="profile-warning-message rounded-lg border border-amber-500/40 bg-amber-500/10 px-4 py-3 mb-4 text-amber-200">
+        <div class="notice profile-warning-message notice--warning">
             {{ profile_warning_message }}
-            <a href="/edit-profile" class="ml-1 underline hover:text-amber-100">Update profile</a>
+            <a href="/edit-profile">Update profile</a>
         </div>
         {% endif %}
 
-        <p class="subtitle mt-1 mb-6 text-zinc-300">Fill out up to 10 separate purchase requests and submit them all together</p>
+        <div class="dashboard-grid">
+            <aside class="profile-panel user-info">
+                <div class="profile-panel__top">
+                    <p class="panel-kicker">Requester</p>
+                    <h2>{{ name }}</h2>
+                    <p>{{ team }}</p>
+                    <p class="requester-email">{{ email }}</p>
+                </div>
 
-        <div class="user-info rounded-xl border border-zinc-700/70 bg-zinc-900/45 p-4 mb-8">
-            <div class="info-summary grid gap-2 md:grid-cols-3 text-sm">
-                <p><strong>Name:</strong> {{ name }}</p>
-                <p><strong>Team:</strong> {{ team }}</p>
-                <p><strong>McMaster Email:</strong> {{ email }}</p>
-            </div>
-        </div>
+                <div class="profile-note">
+                    <p>Submit one complete batch when your CAD reimbursement total is at least $100.</p>
+                </div>
+            </aside>
 
+            <main class="workflow-panel dashboard-section">
+                <form method="POST" action="/submit-all-requests" enctype="multipart/form-data">
+                    <input type="hidden" id="profile-is-complete" value="{{ 'true' if profile_is_complete else 'false' }}">
 
-        <form method="POST" action="/submit-all-requests" enctype="multipart/form-data">
-            <!-- Hidden field for client-side submission state -->
-            <input type="hidden" id="profile-is-complete" value="{{ 'true' if profile_is_complete else 'false' }}">
-
-            <div class="dashboard-section">
-                <h2 class="text-2xl font-semibold text-white mt-0">Your Purchase Request Forms</h2>
-                <p class="dashboard-help text-zinc-400 mb-5">Fill out any number of the forms below. Empty forms will be ignored when you
-                    submit.</p>
-
-                <div class="forms-container space-y-4">
-                    {% for form_num in range(1, 11) %}
-                    <div class="form-accordion rounded-xl border border-zinc-700/70 bg-zinc-900/50 overflow-hidden" data-form="{{ form_num }}">
-                        <div class="form-accordion-header flex items-center justify-between gap-3 px-4 py-3 cursor-pointer hover:bg-zinc-800/60 transition-colors" data-action="toggle-form" data-form="{{ form_num }}">
-                            <h3 class="m-0 text-lg font-medium text-zinc-100">Invoice #{{ form_num }}</h3>
-                            <div class="form-header-actions flex items-center gap-3">
-                                <button type="button" class="btn-clear inline-flex items-center rounded-md border border-zinc-600 px-2.5 py-1 text-xs text-zinc-300 hover:bg-zinc-700/60"
-                                    data-action="clear-form" data-form="{{ form_num }}"
-                                    title="Clear this form">Clear</button>
-                                <span class="form-toggle text-zinc-400 text-sm" data-role="accordion-toggle">▼</span>
-                            </div>
+                    <div class="section-heading">
+                        <div>
+                            <p class="section-kicker">Batch Entry</p>
+                            <h2>Your Purchase Request Forms</h2>
                         </div>
-                        <div class="form-accordion-content px-4 pb-4 border-t border-zinc-800" id="form-{{ form_num }}">
-                            <div class="reimbursement-form space-y-5 pt-4">
-                                <div class="form-group">
-                                    <label for="vendor_name_{{ form_num }}" class="block mb-2 text-sm font-medium text-zinc-200">Vendor/Store Name</label>
-                                    <input type="text" id="vendor_name_{{ form_num }}" name="vendor_name_{{ form_num }}"
-                                        placeholder="Enter the name of the vendor or store" class="w-full rounded-lg border border-zinc-700 bg-zinc-900/80 px-3 py-2.5 text-sm text-zinc-100 placeholder-zinc-500 focus:outline-none focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/30">
-                                </div>
-
-                                <div class="form-group">
-                                    <label for="currency_{{ form_num }}" class="block mb-2 text-sm font-medium text-zinc-200">Currency</label>
-                                    <select id="currency_{{ form_num }}" name="currency_{{ form_num }}"
-                                        data-action="currency-select" data-form="{{ form_num }}" class="w-full rounded-lg border border-zinc-700 bg-zinc-900/80 px-3 py-2.5 text-sm text-zinc-100 focus:outline-none focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/30">
-                                        <option value="CAD">CAD - Canadian Dollar</option>
-                                        <option value="USD">USD - US Dollar</option>
-                                    </select>
-                                    <small class="file-help mt-2 block text-xs text-zinc-400">Select the currency used for this purchase</small>
-                                </div>
-
-                                <div class="form-group">
-                                    <label for="invoice_file_{{ form_num }}" class="block mb-2 text-sm font-medium text-zinc-200">Upload Invoice/Receipt</label>
-                                    <div class="custom-file-upload">
-                                        <div class="file-drop-area rounded-lg border border-dashed border-zinc-600 bg-zinc-900/70 p-4 text-center transition-colors"
-                                            data-role="file-drop-area"
-                                            data-input-id="invoice_file_{{ form_num }}"
-                                            data-filename-id="invoice-filename-{{ form_num }}">
-                                            <input type="file" id="invoice_file_{{ form_num }}"
-                                                name="invoice_file_{{ form_num }}"
-                                                accept=".pdf,.jpg,.jpeg,.png,.gif"
-                                                data-filename-id="invoice-filename-{{ form_num }}" class="hidden">
-                                            <p class="drop-text m-0 text-sm text-zinc-300">
-                                                <span class="file-upload cursor-pointer text-indigo-300 hover:text-indigo-200" data-role="file-upload-text" data-input-id="invoice_file_{{ form_num }}">
-                                                    <b>Choose a file</b> or drag it here
-                                                </span>
-                                            </p>
-                                        </div>
-                                        <span class="file-name mt-2 block text-sm text-zinc-400" id="invoice-filename-{{ form_num }}">No file
-                                            chosen</span>
-                                    </div>
-                                    <small class="file-help mt-2 block text-xs text-zinc-400">Please upload your invoice or receipt (PDF, JPG, PNG, or
-                                        GIF format)</small>
-                                </div>
-
-                                <div class="form-group proof-of-payment-section proof-of-payment-section-{{ form_num }}"
-                                    style="display: none;">
-                                    <label for="proof_of_payment_{{ form_num }}" class="block mb-2 text-sm font-medium text-zinc-200">Proof of Payment (Required for USD
-                                        purchases)</label>
-                                    <div class="custom-file-upload">
-                                        <div class="file-drop-area rounded-lg border border-dashed border-zinc-600 bg-zinc-900/70 p-4 text-center transition-colors"
-                                            data-role="file-drop-area"
-                                            data-input-id="proof_of_payment_{{ form_num }}"
-                                            data-filename-id="payment-filename-{{ form_num }}">
-                                            <input type="file" id="proof_of_payment_{{ form_num }}"
-                                                name="proof_of_payment_{{ form_num }}"
-                                                accept=".pdf,.jpg,.jpeg,.png,.gif"
-                                                data-filename-id="payment-filename-{{ form_num }}" class="hidden">
-                                            <p class="drop-text m-0 text-sm text-zinc-300">
-                                                <span class="file-upload cursor-pointer text-indigo-300 hover:text-indigo-200" data-role="file-upload-text" data-input-id="proof_of_payment_{{ form_num }}">
-                                                    <b>Choose a file</b> or drag it here
-                                                </span>
-                                            </p>
-                                        </div>
-                                        <span class="file-name mt-2 block text-sm text-zinc-400" id="payment-filename-{{ form_num }}">No file
-                                            chosen</span>
-                                    </div>
-                                    <small class="file-help mt-2 block text-xs text-zinc-400">Upload a screenshot of your bank transaction or payment
-                                        confirmation (PDF, JPG, PNG, or GIF format)</small>
-                                </div>
-
-                                <div class="items-section rounded-lg border border-zinc-700/70 bg-zinc-900/40 p-4">
-                                    <h4 class="m-0 text-base font-semibold text-zinc-100">Item Details</h4>
-                                    <small class="items-help mt-1 block text-xs text-zinc-400">Add the items you purchased (up to 15 items)</small>
-
-                                    <div id="items-container-{{ form_num }}" class="space-y-3 mt-3">
-                                        <div class="item-row grid gap-3 md:grid-cols-12 p-3 rounded-lg border border-zinc-700/70 bg-zinc-900/70">
-                                            <div class="item-input-group md:col-span-3">
-                                                <label class="block mb-1 text-xs font-medium text-zinc-300">Item Name</label>
-                                                <input type="text" name="item_name_{{ form_num }}_1"
-                                                    placeholder="Enter item name" class="w-full rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm text-zinc-100 placeholder-zinc-500 focus:outline-none focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/30">
-                                            </div>
-                                            <div class="item-input-group md:col-span-3">
-                                                <label class="block mb-1 text-xs font-medium text-zinc-300">Usage/Purpose</label>
-                                                <input type="text" name="item_usage_{{ form_num }}_1"
-                                                    placeholder="What is this item for?" class="w-full rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm text-zinc-100 placeholder-zinc-500 focus:outline-none focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/30">
-                                            </div>
-                                            <div class="item-input-group md:col-span-2">
-                                                <label class="block mb-1 text-xs font-medium text-zinc-300">Quantity</label>
-                                                <input type="number" name="item_quantity_{{ form_num }}_1" min="1"
-                                                    value="1" data-action="calc-item" data-form="{{ form_num }}" data-item="1" class="w-full rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm text-zinc-100 focus:outline-none focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/30">
-                                            </div>
-                                            <div class="item-input-group md:col-span-2">
-                                                <label class="block mb-1 text-xs font-medium text-zinc-300">Item Cost (<span class="currency-label-{{ form_num }}">CAD</span>)</label>
-                                                <input type="number" name="item_price_{{ form_num }}_1" min="0"
-                                                    step="0.00000001" placeholder="0.00"
-                                                    data-action="calc-item" data-form="{{ form_num }}" data-item="1" class="w-full rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm text-zinc-100 placeholder-zinc-500 focus:outline-none focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/30">
-                                            </div>
-                                            <div class="item-input-group md:col-span-1">
-                                                <label class="block mb-1 text-xs font-medium text-zinc-300">Total</label>
-                                                <input type="number" name="item_total_{{ form_num }}_1" readonly
-                                                    placeholder="0.00" class="total-field w-full rounded-md border border-zinc-700 bg-zinc-800/70 px-3 py-2 text-sm text-zinc-200">
-                                            </div>
-                                            <div class="item-actions md:col-span-1 flex items-end">
-                                                <button type="button" class="btn-remove w-full rounded-md border border-red-500/50 px-2 py-2 text-xs text-red-300 hover:bg-red-500/15"
-                                                    data-action="remove-item" data-form="{{ form_num }}"
-                                                    style="display: none;">Remove</button>
-                                            </div>
-                                        </div>
-                                    </div>
-
-                                    <div class="form-group">
-                                        <button type="button" class="btn-secondary inline-flex items-center rounded-md border border-indigo-500/50 px-3 py-2 text-sm text-indigo-300 hover:bg-indigo-500/15 transition-colors"
-                                            data-action="add-item" data-form="{{ form_num }}">Add Another Item</button>
-                                    </div>
-                                </div>
-
-                                <div class="total-section rounded-lg border border-zinc-700/70 bg-zinc-900/40 p-4">
-                                    <h4 class="m-0 text-base font-semibold text-zinc-100 mb-3">Financial Summary</h4>
-
-                                    <!-- CAD Financial Breakdown -->
-                                    <div class="financial-breakdown cad-breakdown-{{ form_num }} space-y-3">
-                                        <div class="form-row">
-                                            <div class="form-group">
-                                                <label for="subtotal_amount_{{ form_num }}" class="block mb-1 text-sm font-medium text-zinc-200">Subtotal (<span
-                                                        class="currency-label-{{ form_num }}">CAD</span>)</label>
-                                                <input type="number" id="subtotal_amount_{{ form_num }}"
-                                                    name="subtotal_amount_{{ form_num }}" readonly min="0" step="0.01"
-                                                    placeholder="0.00" class="total-field w-full rounded-lg border border-zinc-700 bg-zinc-800/70 px-3 py-2 text-sm text-zinc-200">
-                                                <small class="financial-help mt-1 block text-xs text-zinc-400">Automatically calculated from item totals
-                                                    above</small>
-                                            </div>
-                                        </div>
-
-                                        <div class="form-row">
-                                            <div class="form-group">
-                                                <label for="discount_amount_{{ form_num }}" class="block mb-1 text-sm font-medium text-zinc-200">Discount (<span
-                                                        class="currency-label-{{ form_num }}">CAD</span>)</label>
-                                                <input type="number" id="discount_amount_{{ form_num }}"
-                                                    name="discount_amount_{{ form_num }}" min="0" step="0.01"
-                                                    placeholder="0.00" data-action="recalc-total" data-format="money" data-form="{{ form_num }}" class="w-full rounded-lg border border-zinc-700 bg-zinc-900/80 px-3 py-2 text-sm text-zinc-100 placeholder-zinc-500 focus:outline-none focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/30">
-                                                <small class="financial-help mt-1 block text-xs text-zinc-400">Coupons, promotional discounts, or
-                                                    rebates</small>
-                                            </div>
-                                        </div>
-
-                                        <div class="form-row">
-                                            <div class="form-group">
-                                                <label for="hst_gst_amount_{{ form_num }}" class="block mb-1 text-sm font-medium text-zinc-200"><span
-                                                        class="tax-label-{{ form_num }}">HST/GST</span> (<span
-                                                        class="currency-label-{{ form_num }}">CAD</span>) <span
-                                                        class="required-indicator-{{ form_num }}"></span></label>
-                                                <input type="number" id="hst_gst_amount_{{ form_num }}"
-                                                    name="hst_gst_amount_{{ form_num }}" min="0" step="0.01"
-                                                    placeholder="0.00" data-action="recalc-total" data-format="money" data-form="{{ form_num }}" class="w-full rounded-lg border border-zinc-700 bg-zinc-900/80 px-3 py-2 text-sm text-zinc-100 placeholder-zinc-500 focus:outline-none focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/30">
-                                                <small class="financial-help tax-help-{{ form_num }} mt-1 block text-xs text-zinc-400">Harmonized Sales
-                                                    Tax / Goods and Services Tax</small>
-                                            </div>
-                                        </div>
-
-                                        <div class="form-row">
-                                            <div class="form-group">
-                                                <label for="shipping_amount_{{ form_num }}" class="block mb-1 text-sm font-medium text-zinc-200">Shipping & Handling (<span
-                                                        class="currency-label-{{ form_num }}">CAD</span>)</label>
-                                                <input type="number" id="shipping_amount_{{ form_num }}"
-                                                    name="shipping_amount_{{ form_num }}" min="0" step="0.01"
-                                                    placeholder="0.00" data-action="recalc-total" data-format="money" data-form="{{ form_num }}" class="w-full rounded-lg border border-zinc-700 bg-zinc-900/80 px-3 py-2 text-sm text-zinc-100 placeholder-zinc-500 focus:outline-none focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/30">
-                                                <small class="financial-help mt-1 block text-xs text-zinc-400">Shipping, delivery, and handling
-                                                    fees</small>
-                                            </div>
-                                        </div>
-
-                                    </div>
-
-                                    <!-- USD Financial Breakdown -->
-                                    <div class="financial-breakdown usd-breakdown-{{ form_num }} space-y-3"
-                                        style="display: none;">
-                                        <div class="form-row">
-                                            <div class="form-group">
-                                                <label for="us_subtotal_{{ form_num }}" class="block mb-1 text-sm font-medium text-zinc-200">US Subtotal (USD)</label>
-                                                <input type="number" id="us_subtotal_{{ form_num }}"
-                                                    name="us_subtotal_{{ form_num }}" readonly min="0" step="0.01"
-                                                    placeholder="0.00" class="total-field w-full rounded-lg border border-zinc-700 bg-zinc-800/70 px-3 py-2 text-sm text-zinc-200">
-                                                <small class="financial-help mt-1 block text-xs text-zinc-400">Automatically calculated from item costs above</small>
-                                            </div>
-                                        </div>
-
-                                        <div class="form-row">
-                                            <div class="form-group">
-                                                <label for="us_additional_fees_{{ form_num }}" class="block mb-1 text-sm font-medium text-zinc-200">Additional Fees (USD)</label>
-                                                <input type="number" id="us_additional_fees_{{ form_num }}"
-                                                    name="us_additional_fees_{{ form_num }}" min="0" step="0.01"
-                                                    placeholder="0.00" data-format="money" class="w-full rounded-lg border border-zinc-700 bg-zinc-900/80 px-3 py-2 text-sm text-zinc-100 placeholder-zinc-500 focus:outline-none focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/30">
-                                                <small class="financial-help mt-1 block text-xs text-zinc-400">Taxes, tariffs, shipping, or other fees not included in item costs</small>
-                                            </div>
-                                        </div>
-                                    </div>
-
-                                    <div class="form-row total-row mt-3">
-                                        <div class="form-group">
-                                            <label for="total_cad_amount_{{ form_num }}" class="block mb-1 text-sm font-medium text-zinc-200"><span class="total-label-{{ form_num }}">Total Reimbursement Amount</span>
-                                                (CAD)</label>
-                                            <input type="number" id="total_cad_amount_{{ form_num }}"
-                                                name="total_cad_amount_{{ form_num }}" readonly min="0" step="0.01"
-                                                placeholder="0.00" data-format="money" data-form="{{ form_num }}" class="total-field w-full rounded-lg border border-zinc-700 bg-zinc-800/70 px-3 py-2 text-sm text-zinc-200">
-                                            <small class="financial-help total-help-{{ form_num }} mt-1 block text-xs text-zinc-400">Automatically calculated (Subtotal -
-                                                Discount + Tax + Shipping)</small>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                        <p class="dashboard-help">Empty forms are ignored at submission.</p>
                     </div>
-                    {% endfor %}
-                </div>
-            </div>
 
-            <div class="dashboard-actions mt-8">
-                <div class="form-group">
-                    <button
-                        type="submit"
-                        id="submit-all-btn"
-                        class="btn btn-large w-full md:w-auto inline-flex items-center justify-center rounded-lg bg-gradient-to-br from-[#6366f1] to-[#8b5cf6] text-white border-none px-6 py-3 text-sm font-medium transition-all duration-200 hover:from-[#4f46e5] hover:to-[#7c3aed] hover:shadow-[0_4px_12px_rgba(99,102,241,0.3)] disabled:opacity-60 disabled:cursor-not-allowed disabled:hover:from-[#6366f1] disabled:hover:to-[#8b5cf6]"
-                        {% if not profile_is_complete %}disabled aria-disabled="true"{% endif %}
-                    >
-                        Submit All Purchase Requests
-                    </button>
-                    {% if not profile_is_complete %}
-                    <p class="mt-2 text-sm text-amber-200">
-                        Submission is disabled until your profile is complete.
-                    </p>
-                    {% endif %}
-                </div>
-            </div>
-        </form>
+                    <div class="forms-container forms-stack">
+                        {% for form_num in range(1, 11) %}
+                        {{ invoice_form(form_num) }}
+                        {% endfor %}
+                    </div>
+
+                    <div class="dashboard-actions">
+                        <button type="submit" id="submit-all-btn" class="button button--primary btn btn-large" {% if not profile_is_complete %}disabled aria-disabled="true"{% endif %}>
+                            Submit All Purchase Requests
+                        </button>
+                        {% if not profile_is_complete %}
+                        <p class="submit-note">Submission is disabled until your profile is complete.</p>
+                        {% endif %}
+                    </div>
+                </form>
+            </main>
+        </div>
     </div>
 
     <template id="item-row-template">
-        <div class="item-row grid gap-3 md:grid-cols-12 p-3 rounded-lg border border-zinc-700/70 bg-zinc-900/70">
-            <div class="item-input-group md:col-span-3">
-                <label class="block mb-1 text-xs font-medium text-zinc-300">Item Name</label>
-                <input type="text" name="item_name___FORM_____ITEM__"
-                    placeholder="Enter item name" class="w-full rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm text-zinc-100 placeholder-zinc-500 focus:outline-none focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/30">
-            </div>
-            <div class="item-input-group md:col-span-3">
-                <label class="block mb-1 text-xs font-medium text-zinc-300">Usage/Purpose</label>
-                <input type="text" name="item_usage___FORM_____ITEM__"
-                    placeholder="What is this item for?" class="w-full rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm text-zinc-100 placeholder-zinc-500 focus:outline-none focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/30">
-            </div>
-            <div class="item-input-group md:col-span-2">
-                <label class="block mb-1 text-xs font-medium text-zinc-300">Quantity</label>
-                <input type="number" name="item_quantity___FORM_____ITEM__" min="1"
-                    value="1" data-action="calc-item" data-form="__FORM__" data-item="__ITEM__" class="w-full rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm text-zinc-100 focus:outline-none focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/30">
-            </div>
-            <div class="item-input-group md:col-span-2">
-                <label class="block mb-1 text-xs font-medium text-zinc-300">Item Cost (<span class="currency-label-__FORM__">CAD</span>)</label>
-                <input type="number" name="item_price___FORM_____ITEM__" min="0"
-                    step="0.00000001" placeholder="0.00"
-                    data-action="calc-item" data-form="__FORM__" data-item="__ITEM__" class="w-full rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm text-zinc-100 placeholder-zinc-500 focus:outline-none focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/30">
-            </div>
-            <div class="item-input-group md:col-span-1">
-                <label class="block mb-1 text-xs font-medium text-zinc-300">Total</label>
-                <input type="number" name="item_total___FORM_____ITEM__" readonly
-                    placeholder="0.00" class="total-field w-full rounded-md border border-zinc-700 bg-zinc-800/70 px-3 py-2 text-sm text-zinc-200">
-            </div>
-            <div class="item-actions md:col-span-1 flex items-end">
-                <button type="button" class="btn-remove w-full rounded-md border border-red-500/50 px-2 py-2 text-xs text-red-300 hover:bg-red-500/15"
-                    data-action="remove-item" data-form="__FORM__">Remove</button>
-            </div>
-        </div>
+        {{ item_row("__FORM__", "__ITEM__") }}
     </template>
 
     <script src="/static/js/dashboard.js" defer></script>

--- a/src/templates/edit_profile.html
+++ b/src/templates/edit_profile.html
@@ -5,119 +5,118 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ title }}</title>
-    <link rel="stylesheet" href="/static/css/output.css">
+    <link rel="stylesheet" href="/static/css/output.css?v=amber-ui">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;800&family=Bricolage+Grotesque:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600;700&family=Public+Sans:wght@400;500;600;700;800&display=swap" rel="stylesheet">
     {% include "_sentry.html" %}
 </head>
 
-<body data-google-maps-enabled="{{ 'true' if google_api_key else 'false' }}" class="font-['Inter',-apple-system,BlinkMacSystemFont,sans-serif] m-0 py-12 bg-[#0a0a0c] bg-[radial-gradient(circle_at_50%_0%,#1a1a22_0%,#0a0a0c_70%)] leading-[1.6] min-h-screen text-[#e4e4e7] box-border overflow-y-auto">
-    <div class="max-w-3xl w-[92%] p-10 bg-[rgba(24,24,27,0.82)] rounded-2xl shadow-[0_8px_32px_rgba(0,0,0,0.25)] backdrop-blur-[10px] [-webkit-backdrop-filter:blur(10px)] border border-[rgba(255,255,255,0.08)] my-12 mx-auto">
-        <div class="mb-10 relative">
-            <a href="/dashboard" id="back-link" class="inline-flex items-center gap-1 text-sm text-[#a5b4fc] hover:text-[#c7d2fe] transition-colors mb-4">← Back</a>
-            <h1 class="m-0 text-3xl font-semibold tracking-[-0.025em] text-white text-center">Edit Your Information</h1>
-        </div>
-
-        <form method="post" novalidate enctype="multipart/form-data">
-            <div class="mb-6">
-                <label for="name" class="block mb-2 font-medium text-sm text-[#e4e4e7]">Full Name <span class="text-red-400">*</span></label>
-                <input type="text" id="name" name="name" value="{{ user.name if user else '' }}" required class="w-full py-3.5 px-3.5 bg-[rgba(39,39,42,0.7)] border border-[rgba(63,63,70,0.5)] rounded-lg text-[0.95rem] transition-all duration-200 box-border text-[#e4e4e7] block caret-[#6366f1] focus:outline-none focus:border-[#6366f1] focus:shadow-[0_0_0_2px_rgba(99,102,241,0.2)] placeholder:text-[#71717a]">
+<body data-google-maps-enabled="{{ 'true' if google_api_key else 'false' }}" class="app-page form-page">
+    <main class="app-shell narrow-shell">
+        <header class="page-header">
+            <a href="/dashboard" id="back-link" class="button button--secondary">Back</a>
+            <div>
+                <p class="eyebrow">Requester Profile</p>
+                <h1>Edit Your Information</h1>
+                <p class="subtitle">Keep reimbursement, address, signature, and banking details ready before submitting.</p>
             </div>
+        </header>
 
-            <div class="mb-6">
-                <label for="email" class="block mb-2 font-medium text-sm text-[#e4e4e7]">McMaster Email <span class="text-red-400">*</span></label>
-                <input type="email" id="email" name="email" value="{{ user.email if user else '' }}" required class="w-full py-3.5 px-3.5 bg-[rgba(39,39,42,0.7)] border border-[rgba(63,63,70,0.5)] rounded-lg text-[0.95rem] transition-all duration-200 box-border text-[#e4e4e7] block caret-[#6366f1] focus:outline-none focus:border-[#6366f1] focus:shadow-[0_0_0_2px_rgba(99,102,241,0.2)] placeholder:text-[#71717a]">
-            </div>
-
-            <div class="mb-6">
-                <label for="personal_email" class="block mb-2 font-medium text-sm text-[#e4e4e7]">Personal/E-Transfer Email <span class="text-red-400">*</span></label>
-                <input type="email" id="personal_email" name="personal_email"
-                    value="{{ user.personal_email if user else '' }}" required class="w-full py-3.5 px-3.5 bg-[rgba(39,39,42,0.7)] border border-[rgba(63,63,70,0.5)] rounded-lg text-[0.95rem] transition-all duration-200 box-border text-[#e4e4e7] block caret-[#6366f1] focus:outline-none focus:border-[#6366f1] focus:shadow-[0_0_0_2px_rgba(99,102,241,0.2)] placeholder:text-[#71717a]">
-            </div>
-
-            <div class="mb-6">
-                <label for="team" class="block mb-2 font-medium text-sm text-[#e4e4e7]">Team <span class="text-red-400">*</span></label>
-                <select id="team" name="team" required class="w-full py-3.5 px-3.5 bg-[rgba(39,39,42,0.7)] border border-[rgba(63,63,70,0.5)] rounded-lg text-[0.95rem] transition-all duration-200 box-border text-[#e4e4e7] block caret-[#6366f1] focus:outline-none focus:border-[#6366f1] focus:shadow-[0_0_0_2px_rgba(99,102,241,0.2)]">
-                    <option value="">Select your team</option>
-                    <option value="Aeroshell" {% if user and user.team=='Aeroshell' %}selected{% endif %}>Aeroshell</option>
-                    <option value="Battery" {% if user and user.team=='Battery' %}selected{% endif %}>Battery</option>
-                    <option value="Chassis" {% if user and user.team=='Chassis' %}selected{% endif %}>Chassis</option>
-                    <option value="Data Acquisition" {% if user and user.team=='Data Acquisition' %}selected{% endif %}>Data Acquisition</option>
-                    <option value="Firmware" {% if user and user.team=='Firmware' %}selected{% endif %}>Firmware</option>
-                    <option value="Management" {% if user and user.team=='Management' %}selected{% endif %}>Management</option>
-                    <option value="Media" {% if user and user.team=='Media' %}selected{% endif %}>Media</option>
-                    <option value="Power Management Systems" {% if user and user.team=='Power Management Systems' %}selected{% endif %}>Power Management Systems</option>
-                    <option value="Solar Cells" {% if user and user.team=='Solar Cells' %}selected{% endif %}>Solar Cells</option>
-                    <option value="Strategies" {% if user and user.team=='Strategies' %}selected{% endif %}>Strategies</option>
-                    <option value="Suspension" {% if user and user.team=='Suspension' %}selected{% endif %}>Suspension</option>
-                </select>
-            </div>
-
-            <div class="mb-6">
-                <label for="address" class="block mb-2 font-medium text-sm text-[#e4e4e7]">Address <span class="text-red-400">*</span></label>
-                <textarea id="address" name="address" placeholder="Start typing your address..." required class="w-full py-3.5 px-3.5 bg-[rgba(39,39,42,0.7)] border border-[rgba(63,63,70,0.5)] rounded-lg text-[0.95rem] transition-all duration-200 box-border text-[#e4e4e7] block caret-[#6366f1] focus:outline-none focus:border-[#6366f1] focus:shadow-[0_0_0_2px_rgba(99,102,241,0.2)] placeholder:text-[#71717a] min-h-24 resize-y">{{ user.address if user else '' }}</textarea>
-                <small class="address-help block mt-2 text-xs text-[#a1a1aa]">Start typing and select from suggestions for accurate address</small>
-            </div>
-
-            <div class="mb-8">
-                <label for="signature" class="block mb-2 font-medium text-sm text-[#e4e4e7]">Digital Signature <span class="text-red-400">*</span></label>
-                <div>
-                    <div class="relative flex flex-col items-center justify-center text-center gap-2 border border-dashed border-[rgba(99,102,241,0.45)] bg-[rgba(39,39,42,0.45)] rounded-lg py-5 px-4">
-                        <input type="file" id="signature" name="signature" accept=".png,.jpg,.jpeg"
-                            data-filename-id="signature-name" class="absolute inset-0 w-full h-full opacity-0 cursor-pointer">
-                        <span class="text-sm text-[#c4b5fd]">Click to upload signature image (PNG, JPG, JPEG)</span>
-                    </div>
-                    <div id="signature-name" class="mt-2 text-sm text-[#a1a1aa]"></div>
+        <form method="post" novalidate enctype="multipart/form-data" class="app-card form-card">
+            <div class="form-grid">
+                <div class="field">
+                    <label for="name" class="field-label">Full Name <span class="required-mark">*</span></label>
+                    <input type="text" id="name" name="name" value="{{ user.name if user else '' }}" required class="field-control">
                 </div>
-                {% if signature_data_url %}
-                <div class="mt-3">
-                    <div class="mt-2 rounded-lg border border-[rgba(99,102,241,0.25)] bg-[rgba(39,39,42,0.45)] p-3 inline-block">
-                        <img src="{{ signature_data_url }}" alt="Current signature" class="block max-w-full h-auto max-h-32 rounded">
-                    </div>
+
+                <div class="field">
+                    <label for="email" class="field-label">McMaster Email <span class="required-mark">*</span></label>
+                    <input type="email" id="email" name="email" value="{{ user.email if user else '' }}" required class="field-control">
                 </div>
-                {% else %}
-                <p class="mt-3 text-sm text-[#a1a1aa]">No signature uploaded yet.</p>
-                {% endif %}
+
+                <div class="field">
+                    <label for="personal_email" class="field-label">Personal/E-Transfer Email <span class="required-mark">*</span></label>
+                    <input type="email" id="personal_email" name="personal_email" value="{{ user.personal_email if user else '' }}" required class="field-control">
+                </div>
+
+                <div class="field">
+                    <label for="team" class="field-label">Team <span class="required-mark">*</span></label>
+                    <select id="team" name="team" required class="field-control">
+                        <option value="">Select your team</option>
+                        <option value="Aeroshell" {% if user and user.team=='Aeroshell' %}selected{% endif %}>Aeroshell</option>
+                        <option value="Battery" {% if user and user.team=='Battery' %}selected{% endif %}>Battery</option>
+                        <option value="Chassis" {% if user and user.team=='Chassis' %}selected{% endif %}>Chassis</option>
+                        <option value="Data Acquisition" {% if user and user.team=='Data Acquisition' %}selected{% endif %}>Data Acquisition</option>
+                        <option value="Firmware" {% if user and user.team=='Firmware' %}selected{% endif %}>Firmware</option>
+                        <option value="Management" {% if user and user.team=='Management' %}selected{% endif %}>Management</option>
+                        <option value="Media" {% if user and user.team=='Media' %}selected{% endif %}>Media</option>
+                        <option value="Power Management Systems" {% if user and user.team=='Power Management Systems' %}selected{% endif %}>Power Management Systems</option>
+                        <option value="Solar Cells" {% if user and user.team=='Solar Cells' %}selected{% endif %}>Solar Cells</option>
+                        <option value="Strategies" {% if user and user.team=='Strategies' %}selected{% endif %}>Strategies</option>
+                        <option value="Suspension" {% if user and user.team=='Suspension' %}selected{% endif %}>Suspension</option>
+                    </select>
+                </div>
+
+                <div class="field field--full">
+                    <label for="address" class="field-label">Address <span class="required-mark">*</span></label>
+                    <textarea id="address" name="address" placeholder="Start typing your address..." required class="field-control text-area">{{ user.address if user else '' }}</textarea>
+                    <small class="field-help address-help">Start typing and select from suggestions for accurate address.</small>
+                </div>
             </div>
 
-            <div class="mb-8">
-                <label for="void_cheque" class="block mb-2 font-medium text-sm text-[#e4e4e7]">Void Cheque (PDF only) <span class="text-red-400">*</span></label>
-                <div>
-                    <div class="relative flex flex-col items-center justify-center text-center gap-2 border border-dashed border-[rgba(99,102,241,0.45)] bg-[rgba(39,39,42,0.45)] rounded-lg py-5 px-4">
-                        <input type="file" id="void_cheque" name="void_cheque" accept=".pdf,application/pdf" {% if not void_cheque_data_url %}required{% endif %}
-                            data-filename-id="void-cheque-name" class="absolute inset-0 w-full h-full opacity-0 cursor-pointer">
-                        <span class="text-sm text-[#c4b5fd]">Click to upload your void cheque (PDF only)</span>
+            <section class="document-grid" aria-label="Profile documents">
+                <div class="document-panel">
+                    <label for="signature" class="field-label">Digital Signature <span class="required-mark">*</span></label>
+                    <div class="profile-upload-zone">
+                        <input type="file" id="signature" name="signature" accept=".png,.jpg,.jpeg" data-filename-id="signature-name" class="file-input-overlay">
+                        <span>Upload signature image</span>
+                        <small>PNG, JPG, or JPEG</small>
                     </div>
-                    <div id="void-cheque-name" class="mt-2 text-sm text-[#a1a1aa]"></div>
-                    <small class="block mt-2 text-xs text-[#a1a1aa]">This is required before reimbursement requests can be submitted.</small>
+                    <div id="signature-name" class="file-name"></div>
+                    {% if signature_data_url %}
+                    <div class="document-preview document-preview--image">
+                        <img src="{{ signature_data_url }}" alt="Current signature">
+                    </div>
+                    {% else %}
+                    <p class="muted-copy">No signature uploaded yet.</p>
+                    {% endif %}
                 </div>
-                {% if void_cheque_data_url %}
-                <div class="mt-3">
-                    <small class="text-xs text-[#a1a1aa]">Leave blank to keep your current void cheque</small>
-                    <div class="rounded-lg border border-[rgba(99,102,241,0.25)] bg-[rgba(39,39,42,0.45)] p-2">
-                        <object data="{{ void_cheque_data_url }}" type="application/pdf" class="w-full h-64 rounded">
-                            <p class="text-sm text-[#c4b5fd]">
+
+                <div class="document-panel">
+                    <label for="void_cheque" class="field-label">Void Cheque <span class="required-mark">*</span></label>
+                    <div class="profile-upload-zone">
+                        <input type="file" id="void_cheque" name="void_cheque" accept=".pdf,application/pdf" {% if not void_cheque_data_url %}required{% endif %} data-filename-id="void-cheque-name" class="file-input-overlay">
+                        <span>Upload void cheque</span>
+                        <small>PDF only</small>
+                    </div>
+                    <div id="void-cheque-name" class="file-name"></div>
+                    <small class="field-help">This is required before reimbursements can be submitted.</small>
+                    {% if void_cheque_data_url %}
+                    <div class="document-preview">
+                        <small class="field-help">Leave blank to keep your current void cheque.</small>
+                        <object data="{{ void_cheque_data_url }}" type="application/pdf">
+                            <p>
                                 PDF preview is unavailable in this browser.
-                                <a href="{{ void_cheque_data_url }}" target="_blank" rel="noopener noreferrer" class="underline hover:text-[#ddd6fe]">Open current void cheque</a>
+                                <a href="{{ void_cheque_data_url }}" target="_blank" rel="noopener noreferrer">Open current void cheque</a>
                             </p>
                         </object>
                     </div>
+                    {% else %}
+                    <p class="muted-copy">No void cheque uploaded yet.</p>
+                    {% endif %}
                 </div>
-                {% else %}
-                <p class="mt-3 text-sm text-[#a1a1aa]">No void cheque uploaded yet.</p>
-                {% endif %}
-            </div>
+            </section>
 
-            <button type="submit" class="w-full py-3.5 px-3.5 bg-gradient-to-br from-[#6366f1] to-[#8b5cf6] text-white border-none rounded-lg text-[0.95rem] font-medium cursor-pointer transition-all duration-200 mt-8 hover:from-[#4f46e5] hover:to-[#7c3aed] hover:shadow-[0_4px_12px_rgba(99,102,241,0.3)] hover:-translate-y-px">Update Information</button>
+            <div class="form-actions">
+                <button type="submit" class="button button--primary button--full">Update Information</button>
+            </div>
         </form>
-    </div>
+    </main>
 
     <script src="/static/js/edit-profile.js"></script>
     {% if google_api_key %}
-    <script
-        src="https://maps.googleapis.com/maps/api/js?key={{ google_api_key }}&libraries=places&callback=initAutocomplete"
-        async defer></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key={{ google_api_key }}&libraries=places&callback=initAutocomplete" async defer></script>
     {% endif %}
 </body>
 

--- a/src/templates/error.html
+++ b/src/templates/error.html
@@ -5,16 +5,24 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Server Error</title>
-  <link rel="stylesheet" href="/static/css/output.css">
+  <link rel="stylesheet" href="/static/css/output.css?v=amber-ui">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;800&family=Bricolage+Grotesque:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600;700&family=Public+Sans:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   {% include "_sentry.html" %}
 </head>
 
-<body class="m-0 min-h-screen bg-zinc-950 text-zinc-100 flex items-center justify-center px-6 font-sans">
-  <div class="w-full max-w-2xl rounded-2xl border border-zinc-800 bg-zinc-900/80 p-8 text-center shadow-xl">
-    <h1 class="m-0 text-3xl font-semibold tracking-tight text-white md:text-4xl">Internal Server Error</h1>
-    <p class="mt-4 text-base text-zinc-300 md:text-lg">Something went wrong on our end. <strong class="text-zinc-100">Hold on</strong>, we're investigating the issue.</p>
-    <p class="mt-6 text-sm text-zinc-400"><strong class="text-zinc-200">Need Help?</strong> Please contact Raj on Teams.</p>
-  </div>
+<body class="app-page status-page">
+  <main class="app-shell status-shell">
+    <section class="app-card status-card">
+      <p class="eyebrow">System Alert</p>
+      <h1>Internal Server Error</h1>
+      <p class="subtitle">Something went wrong on our end. We're investigating the issue.</p>
+      <footer class="card-footer">
+        <p><strong>Need help?</strong> Please contact Raj on Teams.</p>
+      </footer>
+    </section>
+  </main>
 </body>
 
 </html>

--- a/src/templates/login.html
+++ b/src/templates/login.html
@@ -5,54 +5,51 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Login - Purchase Request Site</title>
-    <link rel="stylesheet" href="/static/css/output.css">
+    <link rel="stylesheet" href="/static/css/output.css?v=amber-ui">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;800&family=Bricolage+Grotesque:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600;700&family=Public+Sans:wght@400;500;600;700;800&display=swap" rel="stylesheet">
     {% include "_sentry.html" %}
 </head>
 
-<body class="font-['Inter',-apple-system,BlinkMacSystemFont,sans-serif] m-0 py-12 bg-[#0a0a0c] bg-[radial-gradient(circle_at_50%_0%,#1a1a22_0%,#0a0a0c_70%)] leading-[1.6] min-h-screen flex items-center justify-center text-[#e4e4e7] box-border overflow-y-auto">
-    <div class="max-w-[420px] w-[90%] p-10 bg-[rgba(24,24,27,0.8)] rounded-2xl shadow-[0_8px_32px_rgba(0,0,0,0.25)] backdrop-blur-[10px] [-webkit-backdrop-filter:blur(10px)] border border-[rgba(255,255,255,0.08)] my-12 mx-auto">
-        <div class="text-center mb-10 relative">
-            <h1 class="text-white font-semibold text-[1.75rem] mb-3 tracking-[-0.025em]">
-                Sign In
-            </h1>
-            <p class="text-[#a1a1aa] m-0 text-[0.95rem] font-normal">
-                Enter your credentials to access the Purchase Request Portal
-            </p>
-        </div>
-
-        {% if error_message %}
-        <div class="bg-[rgba(239,68,68,0.15)] border border-[rgba(239,68,68,0.3)] text-[#fca5a5] py-3.5 px-3.5 rounded-lg mb-6 text-center text-sm">
-            {{ error_message }}
-        </div>
-        {% endif %}
-
-        <form method="POST" action="/login">
-            <div class="mb-6">
-                <label for="email" class="block mb-2 font-medium text-[#e4e4e7] text-sm">
-                    Email
-                </label>
-                <input type="email" id="email" name="email" required placeholder="macid@mcmaster.ca" value="{{ email or '' }}" class="w-full py-3.5 px-3.5 bg-[rgba(39,39,42,0.7)] border border-[rgba(63,63,70,0.5)] rounded-lg text-[0.95rem] transition-all duration-200 box-border text-[#e4e4e7] font-['Inter',-apple-system,BlinkMacSystemFont,sans-serif] block caret-[#6366f1] focus:outline-none focus:border-[#6366f1] focus:shadow-[0_0_0_2px_rgba(99,102,241,0.2)] placeholder:text-[#71717a]">
+<body class="app-page auth-page">
+    <main class="auth-shell">
+        <section class="auth-card app-card">
+            <div class="brand-lockup">
+                <div>
+                    <p class="eyebrow">Purchase Request</p>
+                    <h1>Sign In</h1>
+                </div>
             </div>
+            <p class="subtitle">Access the reimbursement command center.</p>
 
-            <div class="mb-6">
-                <label for="password" class="block mb-2 font-medium text-[#e4e4e7] text-sm">
-                    Password
-                </label>
-                <input type="password" id="password" name="password" required placeholder="••••••••" class="w-full py-3.5 px-3.5 bg-[rgba(39,39,42,0.7)] border border-[rgba(63,63,70,0.5)] rounded-lg text-[0.95rem] transition-all duration-200 box-border text-[#e4e4e7] font-['Inter',-apple-system,BlinkMacSystemFont,sans-serif] block caret-[#6366f1] focus:outline-none focus:border-[#6366f1] focus:shadow-[0_0_0_2px_rgba(99,102,241,0.2)] placeholder:text-[#71717a]">
+            {% if error_message %}
+            <div class="notice notice--error">
+                {{ error_message }}
             </div>
+            {% endif %}
 
-            <button type="submit" class="w-full py-3.5 px-3.5 bg-gradient-to-br from-[#6366f1] to-[#8b5cf6] text-white border-none rounded-lg text-[0.95rem] font-medium cursor-pointer transition-all duration-200 font-['Inter',-apple-system,BlinkMacSystemFont,sans-serif] mt-6 hover:bg-gradient-to-br hover:from-[#4f46e5] hover:to-[#7c3aed] hover:shadow-[0_4px_12px_rgba(99,102,241,0.3)] hover:-translate-y-px">
-                Sign In
-            </button>
-        </form>
+            <form method="POST" action="/login" class="form-stack">
+                <div class="field">
+                    <label for="email" class="field-label">Email</label>
+                    <input type="email" id="email" name="email" required placeholder="macid@mcmaster.ca" value="{{ email or '' }}" class="field-control">
+                </div>
 
-        <div class="text-center mt-8 pt-6 border-t border-[rgba(63,63,70,0.5)] text-[#a1a1aa] text-sm">
-            <p>Need access? Contact Raj on Teams</p>
-        </div>
-    </div>
+                <div class="field">
+                    <label for="password" class="field-label">Password</label>
+                    <input type="password" id="password" name="password" required placeholder="Password" class="field-control">
+                </div>
+
+                <button type="submit" class="button button--primary button--full">
+                    Sign In
+                </button>
+            </form>
+
+            <footer class="card-footer">
+                <p>Need access? Contact Raj on Teams.</p>
+            </footer>
+        </section>
+    </main>
 </body>
 
 </html>

--- a/src/templates/success.html
+++ b/src/templates/success.html
@@ -5,50 +5,42 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Purchase Request Submitted - Success</title>
-  <link rel="stylesheet" href="/static/css/output.css">
+  <link rel="stylesheet" href="/static/css/output.css?v=amber-ui">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;800&family=Bricolage+Grotesque:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600;700&family=Public+Sans:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   {% include "_sentry.html" %}
 </head>
 
-<body class="m-0 min-h-screen bg-zinc-950 text-zinc-100 px-6 py-10 font-sans">
-  <div class="mx-auto w-full max-w-3xl rounded-2xl border border-zinc-800 bg-zinc-900/80 p-8 shadow-xl md:p-10">
-    <div class="text-center">
-      <div class="text-4xl" aria-hidden="true">🎉</div>
-      <h1 class="mt-3 text-3xl font-semibold tracking-tight text-white md:text-4xl">Purchase Request Submitted Successfully!</h1>
-      <p class="mt-3 text-zinc-300">Your purchase request has been processed and submitted for approval 🥳</p>
-    </div>
+<body class="app-page status-page">
+  <main class="app-shell status-shell">
+    <section class="app-card status-card">
+      <p class="eyebrow">Submitted</p>
+      <h1>Purchase Request Submitted</h1>
 
-    {% if download_info %}
-    <div class="mt-8 rounded-xl border border-indigo-500/40 bg-indigo-500/10 p-5">
-      <h3 class="m-0 text-lg font-semibold text-indigo-200">📄 Your Excel Report is Ready!</h3>
-      <p class="mt-2 text-sm text-zinc-300">Your purchase request has been compiled into an Excel report. You can download it below.</p>
+      {% if download_info %}
+      <div class="request-panel highlight-panel">
+        <p><strong>Your purchase request has been compiled into an Excel report.</strong></p>
+        <div class="meta-row">
+          <span>Generated</span>
+          <strong>{{ current_time.strftime('%B %d, %Y') }}</strong>
+        </div>
+        <a href="{{ download_info.download_url }}" class="button button--primary" download="{{ download_info.excel_file }}">
+          Download Excel Report
+        </a>
+      </div>
+      {% endif %}
 
-      <div class="mt-3 text-sm text-zinc-300">
-        <strong>Generated:</strong> {{ current_time.strftime('%B %d, %Y') }}
+      <div class="status-actions">
+        <a href="/logout" class="button button--danger">Logout</a>
       </div>
 
-      <a href="{{ download_info.download_url }}" class="mt-4 inline-flex items-center rounded-lg bg-gradient-to-br from-[#6366f1] to-[#8b5cf6] px-4 py-2.5 text-sm font-medium text-white transition-all hover:from-[#4f46e5] hover:to-[#7c3aed] hover:shadow-[0_4px_12px_rgba(99,102,241,0.35)]" download="{{ download_info.excel_file }}">
-        📥 Download Excel Report
-      </a>
-    </div>
-    {% endif %}
-
-    <div class="mt-8 rounded-xl border border-zinc-700/80 bg-zinc-900/50 p-5">
-      <h4 class="m-0 text-base font-semibold text-zinc-100">📋 What Happens Next?</h4>
-      <ul class="mb-0 mt-3 list-disc space-y-2 pl-5 text-sm text-zinc-300">
-        <li><strong class="text-zinc-100">Review:</strong> Your purchase request will be reviewed by the appropriate team</li>
-        <li><strong class="text-zinc-100">Approval:</strong> You'll be messaged on Teams if additional information is needed</li>
-      </ul>
-    </div>
-
-    <div class="mt-8">
-      <a href="/logout" class="inline-flex items-center rounded-lg border border-red-500/45 px-4 py-2.5 text-sm text-red-300 transition-colors hover:bg-red-500/15">🚪 Logout</a>
-    </div>
-
-    <div class="mt-10 rounded-lg border border-zinc-700/70 bg-zinc-900/45 p-4 text-sm text-zinc-400">
-      <p class="m-0"><strong class="text-zinc-200">Need Help?</strong> If you have any questions about your purchase request, please contact Raj.</p>
-      <p class="mb-0 mt-2"><strong class="text-zinc-200">Keep Your Receipt:</strong> Keep the purchase request for your own records.</p>
-    </div>
-  </div>
+      <footer class="card-footer">
+        <p><strong>Need help?</strong> If you have any questions about your purchase request, please contact Raj.</p>
+        <p><strong>Keep your receipt:</strong> Keep the purchase request for your own records.</p>
+      </footer>
+    </section>
+  </main>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- reapplies the amber UI redesign from the conflicted pipeline branch onto current `main`
- preserves `main` session-backed routing by removing legacy `user_email` links and dashboard identity fields
- keeps the accidental CI/CD pipeline/Docker/hook changes out of this PR

## Verification
- `uv run ruff check`
- `uv run ruff format --check`
- `uv run ty check`
- `uv run pytest`
- `npm run build:css`

Replaces the conflicted `fix/streamline-cicd-pipeline` PR for the UI work.