### PR TITLE
Clean up reimbursement form display

### DIFF
--- a/src/static/css/input.css
+++ b/src/static/css/input.css
@@ -353,12 +353,19 @@ h4,
   font-size: 1.75rem;
 }
 
-.profile-panel__top > p:not(.panel-kicker) {
-  margin: 0.35rem 0 0;
+.requester-details {
+  display: grid;
+  gap: 0.7rem;
+  margin-top: 0.85rem;
+}
+
+.requester-details .meta-row {
+  margin: 0;
 }
 
 .meta-row span {
   display: block;
+  margin-bottom: 0.18rem;
   color: var(--subtle);
   font-family: var(--font-mono);
   font-size: 0.68rem;
@@ -366,7 +373,8 @@ h4,
   text-transform: uppercase;
 }
 
-.requester-email {
+.requester-email,
+.requester-address {
   overflow-wrap: anywhere;
 }
 
@@ -378,6 +386,10 @@ h4,
 .profile-note p {
   margin: 0;
   font-size: 0.92rem;
+}
+
+.profile-note p + p {
+  margin-top: 0.7rem;
 }
 
 .workflow-panel {

--- a/src/static/js/dashboard.js
+++ b/src/static/js/dashboard.js
@@ -48,10 +48,12 @@ function formatScaledAmount(scaledValue, decimalPlaces) {
     const isNegative = scaledValue < 0n;
     const absoluteValue = isNegative ? -scaledValue : scaledValue;
     const wholePart = absoluteValue / scale;
-    const fractionPart = String(absoluteValue % scale).padStart(decimalPlaces, '0');
+    const fractionPart = String(absoluteValue % scale)
+        .padStart(decimalPlaces, '0')
+        .replace(/0+$/, '');
     const sign = isNegative ? '-' : '';
 
-    return `${sign}${wholePart}.${fractionPart}`;
+    return fractionPart ? `${sign}${wholePart}.${fractionPart}` : `${sign}${wholePart}`;
 }
 
 function roundScaledAmount(scaledValue, fromDecimalPlaces, toDecimalPlaces) {

--- a/src/templates/dashboard.html
+++ b/src/templates/dashboard.html
@@ -51,12 +51,29 @@
                 <div class="profile-panel__top">
                     <p class="panel-kicker">Requester</p>
                     <h2>{{ name }}</h2>
-                    <p>{{ team }}</p>
-                    <p class="requester-email">{{ email }}</p>
+                    <div class="requester-details">
+                        <p class="meta-row">
+                            <span>Team</span>
+                            {{ team }}
+                        </p>
+                        <p class="meta-row requester-email">
+                            <span>McMaster Email</span>
+                            {{ email }}
+                        </p>
+                        <p class="meta-row requester-email">
+                            <span>Personal Email</span>
+                            {{ e_transfer_email }}
+                        </p>
+                        <p class="meta-row requester-address">
+                            <span>Address</span>
+                            {{ address }}
+                        </p>
+                    </div>
                 </div>
 
                 <div class="profile-note">
                     <p>Submit one complete batch when your CAD reimbursement total is at least $100.</p>
+                    <p>Make sure your information on file is up to date before submitting.</p>
                 </div>
             </aside>
 

--- a/src/templates/edit_profile.html
+++ b/src/templates/edit_profile.html
@@ -91,7 +91,6 @@
                         <small>PDF only</small>
                     </div>
                     <div id="void-cheque-name" class="file-name"></div>
-                    <small class="field-help">This is required before reimbursements can be submitted.</small>
                     {% if void_cheque_data_url %}
                     <div class="document-preview">
                         <small class="field-help">Leave blank to keep your current void cheque.</small>


### PR DESCRIPTION
## Summary
- Trim trailing zeroes from autofilled numeric fields on the dashboard
- Remove the void cheque reimbursement helper sentence from the edit profile page

## Tests
- node --check src/static/js/dashboard.js
- formatter behavior check via node
- rg for removed reimbursement helper copy
- git diff --check