### PR TITLE
Add per-invoice purchase dates

### DIFF
--- a/src/data_processing.py
+++ b/src/data_processing.py
@@ -117,11 +117,10 @@ def populate_expense_rows_from_submitted_forms(
     ws: Worksheet, submitted_forms: list[Invoice]
 ) -> None:
     """Populate expense report rows from submitted form data."""
-    current_date = datetime.now().strftime("%Y-%m-%d")
-
     for i, form in enumerate(submitted_forms):
         row = EXPENSE_REPORT_START_ROW + i
-        ws[f"B{row}"] = current_date
+        ws[f"B{row}"] = form.purchase_date
+        ws[f"B{row}"].number_format = "yyyy-mm-dd"
         ws[f"C{row}"] = form.vendor_name
 
         if not form.is_usd:
@@ -195,7 +194,8 @@ def create_purchase_request(
                 ),
             )
 
-            ws["B1"] = now.strftime("%Y-%m-%d")
+            ws["B1"] = form.purchase_date
+            ws["B1"].number_format = "yyyy-mm-dd"
             ws["D1"] = "USD" if form.is_usd else "CAD"
             ws["B3"] = user_info.name
             ws["D3"] = user_info.e_transfer_email

--- a/src/models/submissions.py
+++ b/src/models/submissions.py
@@ -5,9 +5,10 @@ dashboard router, data processing (Excel generation), Google Drive/Sheets
 clients, and tests.
 """
 
+from datetime import date
 from typing import Annotated
 
-from pydantic import BaseModel, BeforeValidator, ConfigDict, Field
+from pydantic import BaseModel, BeforeValidator, ConfigDict, Field, field_validator
 
 
 def _blank_to_zero(value: object) -> object:
@@ -40,6 +41,7 @@ class Invoice(BaseModel):
 
     form_number: int = Field(ge=1)
     vendor_name: str = Field(min_length=1)
+    purchase_date: date
     is_usd: bool
     invoice_filename: str = Field(min_length=1)
     invoice_file_location: str = Field(min_length=1)
@@ -53,6 +55,13 @@ class Invoice(BaseModel):
     us_subtotal: NonNegFloat
     us_additional_fees: NonNegFloat
     items: list[SubmissionLineItem] = Field(min_length=1)
+
+    @field_validator("purchase_date")
+    @classmethod
+    def purchase_date_cannot_be_in_future(cls, value: date) -> date:
+        if value > date.today():
+            raise ValueError("Purchase date cannot be in the future")
+        return value
 
     @property
     def us_total(self) -> float:

--- a/src/routers/dashboard.py
+++ b/src/routers/dashboard.py
@@ -212,7 +212,7 @@ def dashboard(
     profile_warning_message = None
 
     if error == "no_forms":
-        error_message = "Please complete at least one invoice form before submitting. Make sure to fill in the vendor name, upload an invoice file, and add at least one item."
+        error_message = "Please complete at least one invoice form before submitting. Make sure to fill in the vendor name, purchase date, upload an invoice file, and add at least one item."
     elif error == "invalid_items":
         error_message = "Please fully complete each item row before submitting."
     elif error == "too_many_items":
@@ -285,6 +285,8 @@ async def _parse_invoice_form(
     if not vendor_name:
         return None
 
+    purchase_date = _form_str(form_data.get(f"purchase_date_{form_num}"))
+
     sentry_sdk.add_breadcrumb(
         category="purchase_flow",
         message=f"Processing form {form_num}: {vendor_name}",
@@ -345,6 +347,7 @@ async def _parse_invoice_form(
             {
                 "form_number": form_num,
                 "vendor_name": vendor_name,
+                "purchase_date": purchase_date,
                 "is_usd": currency == "USD",
                 "invoice_filename": invoice_filename,
                 "invoice_file_location": str(invoice_file_path),

--- a/src/static/js/dashboard.js
+++ b/src/static/js/dashboard.js
@@ -98,6 +98,14 @@ function formatMoneyInput(input) {
     input.value = formatMoneyCents(parseMoneyCents(input.value));
 }
 
+function todayIsoDate() {
+    const today = new Date();
+    const year = today.getFullYear();
+    const month = String(today.getMonth() + 1).padStart(2, '0');
+    const day = String(today.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+}
+
 function formatMoneyFields() {
     const formsToRecalculate = new Set();
 
@@ -418,15 +426,27 @@ function resetFileInput(input, spanId) {
 
 function validateSubmission() {
     let hasValidForm = false;
+    const today = todayIsoDate();
 
     for (let formNumber = 1; formNumber <= maxForms; formNumber++) {
         const vendorName = document.getElementById(`vendor_name_${formNumber}`);
+        const purchaseDate = document.getElementById(`purchase_date_${formNumber}`);
         const invoiceFile = document.getElementById(`invoice_file_${formNumber}`);
         const currencySelect = document.getElementById(`currency_${formNumber}`);
         const proofOfPaymentFile = document.getElementById(`proof_of_payment_${formNumber}`);
 
         if (!vendorName || !vendorName.value.trim()) {
             continue;
+        }
+
+        if (!purchaseDate || !purchaseDate.value) {
+            alert('Please enter a purchase date for Invoice #' + formNumber + ' before submitting.');
+            return false;
+        }
+
+        if (purchaseDate.value > today) {
+            alert('Purchase date for Invoice #' + formNumber + ' cannot be in the future.');
+            return false;
         }
 
         if (!invoiceFile || !invoiceFile.files || invoiceFile.files.length === 0) {
@@ -512,7 +532,7 @@ function validateSubmission() {
     }
 
     if (!hasValidForm) {
-        alert('Please complete at least one invoice form before submitting.\n\nTo complete a form, you need:\n• Vendor/Store Name\n• Invoice file uploaded\n• At least one item with name, usage, quantity, and price\n• Proof of payment (for USD purchases only)');
+        alert('Please complete at least one invoice form before submitting.\n\nTo complete a form, you need:\n• Vendor/Store Name\n• Purchase Date\n• Invoice file uploaded\n• At least one item with name, usage, quantity, and price\n• Proof of payment (for USD purchases only)');
         return false;
     }
 
@@ -542,6 +562,9 @@ function clearForm(formNumber) {
 
     const vendorNameInput = document.getElementById(`vendor_name_${formNumber}`);
     if (vendorNameInput) vendorNameInput.value = '';
+
+    const purchaseDateInput = document.getElementById(`purchase_date_${formNumber}`);
+    if (purchaseDateInput) purchaseDateInput.value = '';
 
     const currencySelect = document.getElementById(`currency_${formNumber}`);
     if (currencySelect) {
@@ -623,6 +646,10 @@ function handleFileDrop(event, inputId, spanId) {
 }
 
 function initializeStaticHandlers() {
+    document.querySelectorAll('input[type="date"][name^="purchase_date_"]').forEach(input => {
+        input.max = todayIsoDate();
+    });
+
     document.querySelectorAll('[data-action="toggle-form"]').forEach(header => {
         header.addEventListener('click', () => toggleForm(Number(header.dataset.form)));
     });

--- a/src/templates/_invoice_form.html
+++ b/src/templates/_invoice_form.html
@@ -64,6 +64,12 @@
                 </div>
 
                 <div class="form-group field">
+                    <label for="purchase_date_{{ form_num }}" class="field-label">Purchase Date</label>
+                    <input type="date" id="purchase_date_{{ form_num }}" name="purchase_date_{{ form_num }}" class="field-control">
+                    <small class="field-help file-help">Date the invoice items were purchased</small>
+                </div>
+
+                <div class="form-group field">
                     <label for="currency_{{ form_num }}" class="field-label">Currency</label>
                     <select id="currency_{{ form_num }}" name="currency_{{ form_num }}" data-action="currency-select" data-form="{{ form_num }}" class="field-control">
                         <option value="CAD">CAD - Canadian Dollar</option>

--- a/tests/api/test_submit_all_requests_pipeline.py
+++ b/tests/api/test_submit_all_requests_pipeline.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from datetime import date, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -60,6 +61,7 @@ def _make_test_client(session_email: str = "test@example.com") -> TestClient:
 def _valid_cad_data_for_form(form_num: int, **overrides: str) -> dict[str, str]:
     data = {
         f"vendor_name_{form_num}": "Amazon",
+        f"purchase_date_{form_num}": "2024-01-15",
         f"currency_{form_num}": "CAD",
         f"subtotal_amount_{form_num}": "100.00",
         f"discount_amount_{form_num}": "0",
@@ -220,9 +222,11 @@ def test_submit_all_requests_full_pipeline_success(monkeypatch, tmp_path) -> Non
 
     assert "purchase_request" in calls
     user_info = calls["purchase_request"][0]
+    submitted_forms = calls["purchase_request"][1]
     assert user_info.name == "Test User"
     assert user_info.email == "test@example.com"
     assert user_info.e_transfer_email == "transfer@example.com"
+    assert submitted_forms[0].purchase_date == date(2024, 1, 15)
     assert "expense_report" in calls
     assert "drive_folder" in calls
     assert "sheets" in calls
@@ -365,6 +369,27 @@ def test_submit_all_requests_no_forms_redirects_with_error(
     assert not session_folder.exists()
 
 
+def test_submit_all_requests_ignores_date_only_empty_form(
+    monkeypatch, tmp_path
+) -> None:
+    import src.routers.dashboard as dashboard_module
+
+    session_folder = _patch_session_folder(
+        monkeypatch, dashboard_module, tmp_path, "session-date-only"
+    )
+    _patch_user_and_profile_files(monkeypatch, dashboard_module, _make_user())
+
+    client = _make_test_client()
+    response = client.post(
+        "/submit-all-requests",
+        data={"purchase_date_1": "2024-01-15"},
+    )
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/dashboard?error=no_forms"
+    assert not session_folder.exists()
+
+
 def test_submit_all_requests_rejects_partial_item_rows(monkeypatch, tmp_path) -> None:
     import src.routers.dashboard as dashboard_module
 
@@ -382,6 +407,52 @@ def test_submit_all_requests_rejects_partial_item_rows(monkeypatch, tmp_path) ->
 
     assert response.status_code == 303
     assert response.headers["location"] == "/dashboard?error=invalid_items"
+    assert not session_folder.exists()
+
+
+def test_submit_all_requests_rejects_missing_purchase_date(
+    monkeypatch, tmp_path
+) -> None:
+    import src.routers.dashboard as dashboard_module
+
+    session_folder = _patch_session_folder(
+        monkeypatch, dashboard_module, tmp_path, "session-missing-purchase-date"
+    )
+    _patch_user_and_profile_files(monkeypatch, dashboard_module, _make_user())
+
+    client = _make_test_client()
+    response = client.post(
+        "/submit-all-requests",
+        data=_valid_cad_data(purchase_date_1=""),
+        files=_invoice_file(),
+    )
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/dashboard?error=invalid_submission"
+    assert not session_folder.exists()
+
+
+def test_submit_all_requests_rejects_future_purchase_date(
+    monkeypatch, tmp_path
+) -> None:
+    import src.routers.dashboard as dashboard_module
+
+    session_folder = _patch_session_folder(
+        monkeypatch, dashboard_module, tmp_path, "session-future-purchase-date"
+    )
+    _patch_user_and_profile_files(monkeypatch, dashboard_module, _make_user())
+
+    client = _make_test_client()
+    response = client.post(
+        "/submit-all-requests",
+        data=_valid_cad_data(
+            purchase_date_1=(date.today() + timedelta(days=1)).isoformat()
+        ),
+        files=_invoice_file(),
+    )
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/dashboard?error=invalid_submission"
     assert not session_folder.exists()
 
 

--- a/tests/integration/test_submit_all_requests_live_pipeline.py
+++ b/tests/integration/test_submit_all_requests_live_pipeline.py
@@ -100,6 +100,7 @@ def test_submit_all_requests_live_pipeline(monkeypatch, tmp_path) -> None:
         "/submit-all-requests",
         data={
             "vendor_name_1": "Live Integration Vendor",
+            "purchase_date_1": "2024-01-15",
             "currency_1": "CAD",
             "subtotal_amount_1": "100.00",
             "discount_amount_1": "0",

--- a/tests/unit/test_data_processing.py
+++ b/tests/unit/test_data_processing.py
@@ -1,4 +1,5 @@
 import re
+from datetime import date, datetime
 from pathlib import Path
 
 import pytest
@@ -22,6 +23,7 @@ def _make_form(**overrides) -> Invoice:
     defaults = {
         "form_number": 1,
         "vendor_name": "Vendor",
+        "purchase_date": date(2024, 1, 15),
         "is_usd": False,
         "invoice_filename": "invoice.pdf",
         "invoice_file_location": "/tmp/invoice.pdf",
@@ -71,6 +73,13 @@ def _expense_report_path(tmp_path: Path) -> Path:
     return files[0]
 
 
+def _as_date(value) -> date:
+    if isinstance(value, datetime):
+        return value.date()
+    assert isinstance(value, date)
+    return value
+
+
 def test_populate_expense_rows_supports_cad_and_usd() -> None:
     wb = Workbook()
     ws = wb.active
@@ -79,6 +88,7 @@ def test_populate_expense_rows_supports_cad_and_usd() -> None:
         _make_form(
             form_number=1,
             vendor_name="CAD Vendor",
+            purchase_date=date(2024, 1, 15),
             is_usd=False,
             subtotal_amount=120.0,
             discount_amount=20.0,
@@ -88,6 +98,7 @@ def test_populate_expense_rows_supports_cad_and_usd() -> None:
         _make_form(
             form_number=2,
             vendor_name="USD Vendor",
+            purchase_date=date(2024, 2, 20),
             is_usd=True,
             proof_of_payment_filename="proof.pdf",
             proof_of_payment_location="/tmp/proof.pdf",
@@ -100,12 +111,16 @@ def test_populate_expense_rows_supports_cad_and_usd() -> None:
     data_processing.populate_expense_rows_from_submitted_forms(ws, submitted_forms)
 
     # First row (CAD) starts at row 6.
+    assert _as_date(ws["B6"].value) == date(2024, 1, 15)
+    assert ws["B6"].number_format == "yyyy-mm-dd"
     assert ws["C6"].value == "CAD Vendor"
     assert ws["F6"].value == 100.0  # subtotal - discount
     assert ws["G6"].value == 113.0
     assert ws["H6"].value == 13.0
 
     # Second row (USD) is row 7.
+    assert _as_date(ws["B7"].value) == date(2024, 2, 20)
+    assert ws["B7"].number_format == "yyyy-mm-dd"
     assert ws["C7"].value == "USD Vendor"
     assert ws["D7"].value == 100.0  # US total
     assert ws["E7"].value == 1.35  # Exchange rate
@@ -172,6 +187,8 @@ def test_create_purchase_request_supports_fifty_item_template_rows(
     try:
         assert wb.sheetnames == ["Receipt1"]
         ws = wb["Receipt1"]
+        assert _as_date(ws["B1"].value) == date(2024, 1, 15)
+        assert ws["B1"].number_format == "yyyy-mm-dd"
         assert ws["B67"].value == "123 Main St"
         assert ws["F59"].value == 125.0
         assert ws["F60"].value == 16.25
@@ -265,6 +282,7 @@ def test_create_purchase_request_populates_receipt25_and_removes_unused_sheets(
     try:
         assert wb.sheetnames == ["Receipt25"]
         ws = wb["Receipt25"]
+        assert _as_date(ws["B1"].value) == date(2024, 1, 15)
         assert ws["B7"].value == "Vendor 25"
         assert ws["B9"].value == "Item"
         assert ws["C9"].value == "Test"
@@ -321,6 +339,8 @@ def test_create_expense_report_supports_twenty_five_rows_and_hides_unused(
     wb = load_workbook(_expense_report_path(tmp_path), data_only=False)
     try:
         ws = wb.active
+        assert _as_date(ws["B6"].value) == date(2024, 1, 15)
+        assert ws["B6"].number_format == "yyyy-mm-dd"
         assert ws["C6"].value == "Vendor 1"
         assert ws[f"C{EXPENSE_REPORT_START_ROW + form_count - 1}"].value == (
             f"Vendor {form_count}"


### PR DESCRIPTION
## Summary
- add a required purchase date field to each completed invoice form
- validate purchase dates on client and server, including rejecting future dates
- write purchase dates into the purchase request and expense report outputs

Closes #280

## Tests
- uv run pytest tests/api/test_submit_all_requests_pipeline.py
- uv run pytest tests/unit/test_data_processing.py
- uv run pytest
- uv run ruff check --fix
- uv run ruff format
- npm run build:css