### PR TITLE
Add past submissions history page

### DIFF
--- a/src/google_sheets.py
+++ b/src/google_sheets.py
@@ -227,7 +227,7 @@ def _parse_past_submissions_from_grid(
             continue
 
         row_color = _dominant_row_color(cells[: len(headers)])
-        legend_label = color_legend.get(row_color)
+        legend_label = color_legend.get(row_color) if row_color else None
         status = _submission_status_from_legend_label(legend_label)
         status_color = (
             row_color

--- a/src/google_sheets.py
+++ b/src/google_sheets.py
@@ -7,6 +7,8 @@ This module handles writing purchase request data to Google Sheets for logging a
 import random
 import ssl
 import time
+from collections import Counter
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
 
@@ -25,6 +27,229 @@ logger = setup_logger(__name__)
 
 # Google Sheets configuration
 SCOPES = ["https://www.googleapis.com/auth/spreadsheets"]
+PAST_SUBMISSIONS_TAB_NAME = "Website Responses"
+COLOR_LEGEND_TAB_NAME = "Color Legend"
+DEFAULT_SUBMISSION_STATUS = "Submitted"
+STATUS_LABEL_OVERRIDES_BY_LEGEND = {
+    "paid": "Paid",
+    "approved by sonya": "Paid",
+    "in review": "In Review",
+    "email drafted": "In Review",
+    "pending": "Pending",
+    "email sent": "Pending",
+}
+PAST_SUBMISSION_HEADERS = (
+    "Timestamp",
+    "Mac Email",
+    "Total Reimbursed",
+    "Google Drive Link",
+)
+
+
+@dataclass(frozen=True)
+class PastSubmission:
+    """User-facing summary of a historical Google Sheets submission row."""
+
+    submitted_at_display: str
+    total_reimbursed: str
+    drive_link: str
+    status: str
+    status_color: str | None = None
+
+
+def _cell_display_value(cell: dict[str, Any] | None) -> str:
+    if not isinstance(cell, dict):
+        return ""
+
+    formatted_value = cell.get("formattedValue")
+    if formatted_value is not None:
+        return str(formatted_value).strip()
+
+    effective_value = cell.get("effectiveValue")
+    if not isinstance(effective_value, dict):
+        return ""
+
+    for key in ("stringValue", "numberValue", "boolValue", "formulaValue"):
+        if key in effective_value:
+            return str(effective_value[key]).strip()
+    return ""
+
+
+def _hex_from_google_color(color: dict[str, Any] | None) -> str | None:
+    if not isinstance(color, dict):
+        return None
+
+    rgb_color = color.get("rgbColor")
+    if isinstance(rgb_color, dict):
+        color = rgb_color
+
+    if not any(channel in color for channel in ("red", "green", "blue")):
+        return None
+
+    channels = []
+    for channel in ("red", "green", "blue"):
+        raw_value = color.get(channel, 0)
+        try:
+            channels.append(max(0, min(255, round(float(raw_value) * 255))))
+        except (TypeError, ValueError):
+            return None
+
+    hex_color = f"#{channels[0]:02X}{channels[1]:02X}{channels[2]:02X}"
+    if hex_color == "#FFFFFF":
+        return None
+    return hex_color
+
+
+def _cell_background_color(cell: dict[str, Any] | None) -> str | None:
+    if not isinstance(cell, dict):
+        return None
+
+    effective_format = cell.get("effectiveFormat")
+    if not isinstance(effective_format, dict):
+        return None
+
+    return _hex_from_google_color(
+        effective_format.get("backgroundColorStyle")
+    ) or _hex_from_google_color(effective_format.get("backgroundColor"))
+
+
+def _dominant_row_color(cells: list[dict[str, Any]]) -> str | None:
+    colors = [color for cell in cells if (color := _cell_background_color(cell))]
+    if not colors:
+        return None
+    return Counter(colors).most_common(1)[0][0]
+
+
+def _sheet_row_data(
+    grid_response: dict[str, Any], sheet_title: str
+) -> list[dict[str, Any]]:
+    for sheet in grid_response.get("sheets", []):
+        properties = sheet.get("properties")
+        if not isinstance(properties, dict) or properties.get("title") != sheet_title:
+            continue
+
+        data = sheet.get("data", [])
+        if not data:
+            return []
+        row_data = data[0].get("rowData", [])
+        return row_data if isinstance(row_data, list) else []
+    raise ValueError(f"Sheet tab not found: {sheet_title}")
+
+
+def _parse_color_legend_from_grid(grid_response: dict[str, Any]) -> dict[str, str]:
+    legend: dict[str, str] = {}
+    for row in _sheet_row_data(grid_response, COLOR_LEGEND_TAB_NAME):
+        cells = row.get("values", [])
+        if not cells:
+            continue
+
+        label = _cell_display_value(cells[0])
+        if not label or "legend" in label.casefold():
+            continue
+
+        color = _cell_background_color(cells[0])
+        if color:
+            legend[color] = label
+    return legend
+
+
+def _submission_status_from_legend_label(label: str | None) -> str:
+    if not label:
+        return DEFAULT_SUBMISSION_STATUS
+    return STATUS_LABEL_OVERRIDES_BY_LEGEND.get(
+        label.casefold(), DEFAULT_SUBMISSION_STATUS
+    )
+
+
+def _header_indexes(headers: list[str]) -> dict[str, int]:
+    normalized_headers = {
+        header.casefold(): index for index, header in enumerate(headers) if header
+    }
+    missing_headers = [
+        header
+        for header in PAST_SUBMISSION_HEADERS
+        if header.casefold() not in normalized_headers
+    ]
+    if missing_headers:
+        raise ValueError(
+            "Missing expected Google Sheets headers: " + ", ".join(missing_headers)
+        )
+    return {
+        header: normalized_headers[header.casefold()]
+        for header in PAST_SUBMISSION_HEADERS
+    }
+
+
+def _value_at(cells: list[dict[str, Any]], index: int) -> str:
+    if index >= len(cells):
+        return ""
+    return _cell_display_value(cells[index])
+
+
+def _parse_submission_timestamp(value: str) -> datetime | None:
+    for date_format in (
+        "%Y-%m-%d %H:%M:%S",
+        "%Y-%m-%d %H:%M",
+        "%Y-%m-%d",
+        "%m/%d/%Y %H:%M:%S",
+        "%m/%d/%Y %H:%M",
+        "%m/%d/%Y %I:%M:%S %p",
+        "%m/%d/%Y %I:%M %p",
+        "%m/%d/%Y",
+    ):
+        try:
+            return datetime.strptime(value, date_format)
+        except ValueError:
+            continue
+    return None
+
+
+def _parse_past_submissions_from_grid(
+    grid_response: dict[str, Any], user_email: str
+) -> list[PastSubmission]:
+    rows = _sheet_row_data(grid_response, PAST_SUBMISSIONS_TAB_NAME)
+    if not rows:
+        return []
+
+    headers = [_cell_display_value(cell) for cell in rows[0].get("values", [])]
+    header_indexes = _header_indexes(headers)
+    color_legend = _parse_color_legend_from_grid(grid_response)
+    normalized_user_email = user_email.strip().casefold()
+
+    parsed_submissions: list[tuple[PastSubmission, datetime | None]] = []
+    for row in rows[1:]:
+        cells = row.get("values", [])
+        if not isinstance(cells, list):
+            continue
+
+        row_email = _value_at(cells, header_indexes["Mac Email"]).casefold()
+        if row_email != normalized_user_email:
+            continue
+
+        row_color = _dominant_row_color(cells[: len(headers)])
+        legend_label = color_legend.get(row_color)
+        status = _submission_status_from_legend_label(legend_label)
+        status_color = (
+            row_color
+            if row_color in color_legend and status != DEFAULT_SUBMISSION_STATUS
+            else None
+        )
+        submitted_at_display = _value_at(cells, header_indexes["Timestamp"])
+        submission = PastSubmission(
+            submitted_at_display=submitted_at_display,
+            total_reimbursed=_value_at(cells, header_indexes["Total Reimbursed"]),
+            drive_link=_value_at(cells, header_indexes["Google Drive Link"]),
+            status=status,
+            status_color=status_color,
+        )
+        parsed_submissions.append(
+            (submission, _parse_submission_timestamp(submitted_at_display))
+        )
+
+    dated_submissions = [entry for entry in parsed_submissions if entry[1] is not None]
+    undated_submissions = [entry for entry in parsed_submissions if entry[1] is None]
+    dated_submissions.sort(key=lambda entry: entry[1] or datetime.min, reverse=True)
+    return [submission for submission, _ in dated_submissions + undated_submissions]
 
 
 class GoogleSheetsClient:
@@ -91,6 +316,46 @@ class GoogleSheetsClient:
                 if attempt >= max_attempts or not self._is_retriable(e):
                     raise
                 time.sleep((2 ** (attempt - 1)) + random.random())
+
+    def list_past_submissions(self, user_email: str) -> list[PastSubmission]:
+        """
+        Return past submissions for a user from the Website Responses tab.
+
+        Status categories are derived from the Color Legend tab by matching row fill colors.
+        """
+        if not self.service and not self._authenticate():
+            raise RuntimeError("Google Sheets client is not authenticated")
+
+        service = self.service
+        if service is None:
+            raise RuntimeError("Google Sheets client is not authenticated")
+
+        try:
+            grid_response = (
+                service.spreadsheets()
+                .get(
+                    spreadsheetId=self.sheet_id,
+                    ranges=[
+                        f"'{PAST_SUBMISSIONS_TAB_NAME}'!A:I",
+                        f"'{COLOR_LEGEND_TAB_NAME}'!A:A",
+                    ],
+                    includeGridData=True,
+                    fields=(
+                        "sheets(properties(title),data(rowData(values("
+                        "formattedValue,effectiveValue,"
+                        "effectiveFormat(backgroundColor,backgroundColorStyle)"
+                        "))))"
+                    ),
+                )
+                .execute()
+            )
+            return _parse_past_submissions_from_grid(grid_response, user_email)
+        except HttpError:
+            logger.exception("HTTP error reading past submissions")
+            raise
+        except Exception:
+            logger.exception("Error reading past submissions")
+            raise
 
     def log_purchase_request(
         self,

--- a/src/main.py
+++ b/src/main.py
@@ -28,6 +28,7 @@ from src.routers.dashboard import router as dashboard_router
 from src.routers.download import router as download_router
 from src.routers.home import router as home_router
 from src.routers.profile import router as profile_router
+from src.routers.submissions import router as submissions_router
 from src.routers.success import router as success_router
 from src.routers.utils import AuthRedirect, limiter, templates
 
@@ -225,6 +226,7 @@ def create_app() -> FastAPI:
     application.include_router(dashboard_router)
     application.include_router(profile_router)
     application.include_router(success_router)
+    application.include_router(submissions_router)
     application.include_router(download_router)
 
     application.state.limiter = limiter

--- a/src/routers/submissions.py
+++ b/src/routers/submissions.py
@@ -1,0 +1,51 @@
+"""
+Past submissions router for the /submissions endpoint.
+"""
+
+from fastapi import APIRouter, Depends, Request
+from starlette.concurrency import run_in_threadpool
+
+from src.core.logging_utils import setup_logger
+from src.google_sheets import GoogleSheetsClient, PastSubmission
+from src.routers.utils import get_authenticated_user_email, templates
+
+logger = setup_logger(__name__)
+
+router = APIRouter(tags=["submissions"])
+
+
+@router.get("/submissions")
+async def past_submissions_page(
+    request: Request,
+    authenticated_email: str = Depends(get_authenticated_user_email),
+):
+    """Display the authenticated user's past reimbursement submissions."""
+    submissions: list[PastSubmission] = []
+    error_message = None
+    sheets_client: GoogleSheetsClient | None = None
+
+    try:
+        sheets_client = GoogleSheetsClient()
+        submissions = await run_in_threadpool(
+            sheets_client.list_past_submissions, authenticated_email
+        )
+    except Exception:
+        logger.exception("Failed to load past submissions")
+        error_message = (
+            "Past submissions are temporarily unavailable. Please try again later."
+        )
+    finally:
+        if sheets_client is not None:
+            await run_in_threadpool(sheets_client.close)
+
+    return templates.TemplateResponse(
+        request=request,
+        name="past_submissions.html",
+        context={
+            "request": request,
+            "title": "Past Submissions",
+            "user_email": authenticated_email,
+            "submissions": submissions,
+            "error_message": error_message,
+        },
+    )

--- a/src/static/css/input.css
+++ b/src/static/css/input.css
@@ -382,6 +382,10 @@ h4,
   border-color: color-mix(in srgb, var(--accent-cool), transparent 50%);
 }
 
+.main-menu-action--history {
+  border-color: color-mix(in srgb, var(--success), transparent 56%);
+}
+
 .main-menu-action__label {
   color: var(--accent);
   font-family: var(--font-mono);
@@ -392,6 +396,10 @@ h4,
 
 .main-menu-action--profile .main-menu-action__label {
   color: var(--accent-cool);
+}
+
+.main-menu-action--history .main-menu-action__label {
+  color: var(--success);
 }
 
 .main-menu-action__title {
@@ -910,6 +918,96 @@ h4,
   margin-top: 0.45rem;
 }
 
+.submissions-panel {
+  overflow: hidden;
+}
+
+.submissions-table-wrap {
+  overflow-x: auto;
+}
+
+.submissions-table {
+  width: 100%;
+  border-collapse: collapse;
+  table-layout: fixed;
+}
+
+.submissions-table th,
+.submissions-table td {
+  border-bottom: 1px solid var(--line);
+  padding: 0.9rem 0.75rem;
+  text-align: left;
+  vertical-align: middle;
+}
+
+.submissions-table th {
+  color: var(--subtle);
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.submissions-table td {
+  color: var(--ink);
+  font-weight: 700;
+  overflow-wrap: anywhere;
+}
+
+.submissions-table th:nth-child(1),
+.submissions-table td:nth-child(1) {
+  width: 26%;
+}
+
+.submissions-table th:nth-child(2),
+.submissions-table td:nth-child(2) {
+  width: 30%;
+}
+
+.submissions-table th:nth-child(3),
+.submissions-table td:nth-child(3) {
+  width: 20%;
+}
+
+.submissions-table th:nth-child(4),
+.submissions-table td:nth-child(4) {
+  width: 24%;
+}
+
+.submission-status {
+  --status-color: var(--accent-cool);
+  display: inline-flex;
+  min-height: 32px;
+  align-items: center;
+  border: 1px solid color-mix(in srgb, var(--status-color), transparent 35%);
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--status-color), transparent 82%);
+  color: var(--ink);
+  font-size: 0.85rem;
+  font-weight: 800;
+  line-height: 1.1;
+  padding: 0.42rem 0.58rem;
+}
+
+.drive-button {
+  min-height: 36px;
+  width: fit-content;
+  padding: 0.58rem 0.72rem;
+}
+
+.empty-state {
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--surface-quiet);
+  padding: 1rem;
+}
+
+.empty-state p {
+  margin: 0;
+  color: var(--muted);
+  font-weight: 800;
+}
+
 @media (prefers-reduced-motion: no-preference) {
   .dashboard-header,
   .page-header,
@@ -1032,4 +1130,63 @@ h4,
     min-width: 0;
   }
 
+  .submissions-table-wrap {
+    overflow: visible;
+  }
+
+  .submissions-table,
+  .submissions-table tbody,
+  .submissions-table tr,
+  .submissions-table td {
+    display: block;
+  }
+
+  .submissions-table thead {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    white-space: nowrap;
+  }
+
+  .submissions-table tr {
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+    background: var(--surface-quiet);
+    padding: 0.25rem 0;
+  }
+
+  .submissions-table tr + tr {
+    margin-top: 0.8rem;
+  }
+
+  .submissions-table td {
+    display: grid;
+    grid-template-columns: minmax(7.5rem, 34%) minmax(0, 1fr);
+    gap: 0.75rem;
+    width: 100%;
+    border-bottom: 0;
+    padding: 0.65rem 0.75rem;
+  }
+
+  .submissions-table th:nth-child(1),
+  .submissions-table th:nth-child(2),
+  .submissions-table th:nth-child(3),
+  .submissions-table th:nth-child(4),
+  .submissions-table td:nth-child(1),
+  .submissions-table td:nth-child(2),
+  .submissions-table td:nth-child(3),
+  .submissions-table td:nth-child(4) {
+    width: 100%;
+  }
+
+  .submissions-table td::before {
+    content: attr(data-label);
+    color: var(--subtle);
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    font-weight: 800;
+    text-transform: uppercase;
+  }
 }

--- a/src/templates/main_menu.html
+++ b/src/templates/main_menu.html
@@ -52,6 +52,12 @@
                 <span class="main-menu-action__title">Edit Information</span>
                 <span class="main-menu-action__copy">Update reimbursement, address, signature, and banking details.</span>
             </a>
+
+            <a href="/submissions" class="app-card main-menu-action main-menu-action--history">
+                <span class="main-menu-action__label">History</span>
+                <span class="main-menu-action__title">Past Submissions</span>
+                <span class="main-menu-action__copy">Review your submitted purchase requests.</span>
+            </a>
         </nav>
     </main>
 </body>

--- a/src/templates/past_submissions.html
+++ b/src/templates/past_submissions.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ title }}</title>
+    <link rel="stylesheet" href="/static/css/output.css?v=amber-ui">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;800&family=Bricolage+Grotesque:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600;700&family=Public+Sans:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+    {% include "_sentry.html" %}
+</head>
+
+<body class="app-page submissions-page">
+    <main class="app-shell">
+        <header class="page-header">
+            <div>
+                <p class="eyebrow">Reimbursements</p>
+                <h1>Past Submissions</h1>
+                <p class="subtitle">{{ user_email }}</p>
+            </div>
+            <div class="action-bar">
+                <a href="/home" class="button button--secondary">Home</a>
+            </div>
+        </header>
+
+        {% if error_message %}
+        <div class="notice notice--error">
+            {{ error_message }}
+        </div>
+        {% endif %}
+
+        <section class="workflow-panel submissions-panel">
+            <div class="section-heading">
+                <div>
+                    <p class="section-kicker">History</p>
+                    <h2>Your Submissions</h2>
+                </div>
+                <p class="dashboard-help">{{ submissions | length }} total</p>
+            </div>
+
+            {% if submissions %}
+            <div class="submissions-table-wrap">
+                <table class="submissions-table">
+                    <thead>
+                        <tr>
+                            <th scope="col">Date</th>
+                            <th scope="col">Status</th>
+                            <th scope="col">Amount</th>
+                            <th scope="col">Drive</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for submission in submissions %}
+                        <tr>
+                            <td data-label="Date">{{ submission.submitted_at_display or "Unknown" }}</td>
+                            <td data-label="Status">
+                                <span class="submission-status" {% if submission.status_color %}style="--status-color: {{ submission.status_color }}"{% endif %}>
+                                    {{ submission.status }}
+                                </span>
+                            </td>
+                            <td data-label="Amount">{{ submission.total_reimbursed or "Pending" }}</td>
+                            <td data-label="Drive">
+                                {% if submission.drive_link %}
+                                <a href="{{ submission.drive_link }}" target="_blank" rel="noopener noreferrer" class="button button--secondary drive-button">Go to Drive</a>
+                                {% else %}
+                                <span class="muted-copy">Unavailable</span>
+                                {% endif %}
+                            </td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+            {% elif not error_message %}
+            <div class="empty-state">
+                <p>No past submissions yet.</p>
+            </div>
+            {% endif %}
+        </section>
+    </main>
+</body>
+
+</html>

--- a/tests/api/test_home_page.py
+++ b/tests/api/test_home_page.py
@@ -62,6 +62,7 @@ def test_home_page_renders_main_menu(monkeypatch) -> None:
     assert "Open Dashboard" not in response.text
     assert 'href="/dashboard"' in response.text
     assert 'href="/edit-profile"' in response.text
+    assert 'href="/submissions"' in response.text
     assert 'href="/logout"' in response.text
     assert "Your profile is incomplete" not in response.text
 

--- a/tests/api/test_past_submissions_page.py
+++ b/tests/api/test_past_submissions_page.py
@@ -1,0 +1,130 @@
+from typing import Any
+
+from fastapi import FastAPI, Request
+from fastapi.responses import RedirectResponse
+from fastapi.testclient import TestClient
+from starlette.middleware.sessions import SessionMiddleware
+
+from src.google_sheets import PastSubmission
+from src.routers.submissions import router as submissions_router
+from src.routers.success import router as success_router
+from src.routers.utils import AuthRedirect, get_authenticated_user_email
+
+
+async def _auth_redirect_handler(request: Request, exc: Exception) -> RedirectResponse:
+    if not isinstance(exc, AuthRedirect):
+        raise exc
+    return RedirectResponse(url=exc.location, status_code=303)
+
+
+def _make_app(authenticated_email: str | None = "user@example.com") -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(SessionMiddleware, secret_key="test-secret")
+    app.include_router(submissions_router)
+    app.add_exception_handler(AuthRedirect, _auth_redirect_handler)
+    if authenticated_email is not None:
+        app.dependency_overrides[get_authenticated_user_email] = lambda: (
+            authenticated_email
+        )
+    return app
+
+
+def test_past_submissions_page_renders_user_submissions(monkeypatch) -> None:
+    import src.routers.submissions as submissions_module
+
+    calls: dict[str, Any] = {}
+
+    class FakeSheetsClient:
+        def list_past_submissions(self, user_email: str) -> list[PastSubmission]:
+            calls["email"] = user_email
+            return [
+                PastSubmission(
+                    submitted_at_display="2026-02-01 09:30:00",
+                    total_reimbursed="$125.50",
+                    drive_link="https://drive.google.com/folders/example",
+                    status="Paid",
+                    status_color="#B6D7A8",
+                )
+            ]
+
+        def close(self) -> None:
+            calls["closed"] = True
+
+    monkeypatch.setattr(submissions_module, "GoogleSheetsClient", FakeSheetsClient)
+
+    client = TestClient(_make_app(), follow_redirects=False)
+    response = client.get("/submissions")
+
+    assert response.status_code == 200
+    assert calls == {"email": "user@example.com", "closed": True}
+    assert "Paid" in response.text
+    assert "$125.50" in response.text
+    assert "Go to Drive" in response.text
+    assert "https://drive.google.com/folders/example" in response.text
+    assert "Software" not in response.text
+    assert "Internal comment" not in response.text
+    assert "Approved by Sonya" not in response.text
+
+
+def test_past_submissions_page_redirects_unauthenticated_users() -> None:
+    client = TestClient(_make_app(authenticated_email=None), follow_redirects=False)
+
+    response = client.get("/submissions")
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/login"
+
+
+def test_past_submissions_page_handles_sheets_errors(monkeypatch) -> None:
+    import src.routers.submissions as submissions_module
+
+    calls: dict[str, bool] = {}
+
+    class FakeSheetsClient:
+        def list_past_submissions(self, _user_email: str) -> list[PastSubmission]:
+            raise RuntimeError("boom")
+
+        def close(self) -> None:
+            calls["closed"] = True
+
+    monkeypatch.setattr(submissions_module, "GoogleSheetsClient", FakeSheetsClient)
+
+    client = TestClient(_make_app(), follow_redirects=False)
+    response = client.get("/submissions")
+
+    assert response.status_code == 200
+    assert calls == {"closed": True}
+    assert "Past submissions are temporarily unavailable" in response.text
+
+
+def test_past_submissions_page_renders_empty_state(monkeypatch) -> None:
+    import src.routers.submissions as submissions_module
+
+    class FakeSheetsClient:
+        def list_past_submissions(self, _user_email: str) -> list[PastSubmission]:
+            return []
+
+        def close(self) -> None:
+            pass
+
+    monkeypatch.setattr(submissions_module, "GoogleSheetsClient", FakeSheetsClient)
+
+    client = TestClient(_make_app(), follow_redirects=False)
+    response = client.get("/submissions")
+
+    assert response.status_code == 200
+    assert "No past submissions yet." in response.text
+
+
+def test_success_page_links_to_home() -> None:
+    app = FastAPI()
+    app.add_middleware(SessionMiddleware, secret_key="test-secret")
+    app.include_router(success_router)
+    app.dependency_overrides[get_authenticated_user_email] = lambda: "user@example.com"
+
+    client = TestClient(app, follow_redirects=False)
+    response = client.get("/success")
+
+    assert response.status_code == 200
+    assert 'href="/home"' in response.text
+    assert 'href="/submissions"' not in response.text

--- a/tests/unit/test_google_sheets_past_submissions.py
+++ b/tests/unit/test_google_sheets_past_submissions.py
@@ -1,0 +1,207 @@
+from typing import Any
+
+from src.google_sheets import _parse_past_submissions_from_grid
+
+
+def _color(hex_color: str) -> dict[str, float]:
+    clean_color = hex_color.removeprefix("#")
+    return {
+        "red": int(clean_color[0:2], 16) / 255,
+        "green": int(clean_color[2:4], 16) / 255,
+        "blue": int(clean_color[4:6], 16) / 255,
+    }
+
+
+def _cell(value: str = "", fill: str | None = None) -> dict[str, Any]:
+    cell: dict[str, Any] = {"formattedValue": value}
+    if fill is not None:
+        cell["effectiveFormat"] = {"backgroundColor": _color(fill)}
+    return cell
+
+
+def _row(*cells: dict[str, Any]) -> dict[str, list[dict[str, Any]]]:
+    return {"values": list(cells)}
+
+
+def _sheet(title: str, rows: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "properties": {"title": title},
+        "data": [{"rowData": rows}],
+    }
+
+
+def _grid_response(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "sheets": [
+            _sheet("Website Responses", rows),
+            _sheet(
+                "Color Legend",
+                [
+                    _row(_cell("LEGEND (by color code)", "#EDEDED")),
+                    _row(_cell("Paid", "#B6D7A8")),
+                    _row(_cell("In Review", "#F4CCCC")),
+                    _row(_cell("Pending", "#00FFFF")),
+                ],
+            ),
+        ]
+    }
+
+
+def _submission_row(
+    timestamp: str,
+    email: str,
+    amount: str,
+    fill: str | None = None,
+    drive_link: str = "https://drive.google.com/folders/example",
+) -> dict[str, Any]:
+    values = [
+        timestamp,
+        "Requester Name",
+        email,
+        "123 Main St",
+        "transfer@example.com",
+        "Software",
+        amount,
+        drive_link,
+        "Internal comment",
+    ]
+    return _row(*[_cell(value, fill) for value in values])
+
+
+def test_parse_past_submissions_filters_maps_statuses_and_sorts() -> None:
+    grid_response = _grid_response(
+        [
+            _row(
+                _cell("Timestamp"),
+                _cell("Name"),
+                _cell("Mac Email"),
+                _cell("Address"),
+                _cell("E-transfer Email"),
+                _cell("Team"),
+                _cell("Total Reimbursed"),
+                _cell("Google Drive Link"),
+                _cell("Comments"),
+            ),
+            _submission_row(
+                "2026-01-01 10:00:00",
+                "User@Example.com",
+                "$100.00",
+                "#F4CCCC",
+            ),
+            _submission_row(
+                "2026-03-01 09:30:00",
+                "other@example.com",
+                "$999.00",
+                "#B6D7A8",
+            ),
+            _submission_row(
+                "2026-02-01 09:30:00",
+                "user@example.com",
+                "$125.50",
+                "#B6D7A8",
+            ),
+            _submission_row(
+                "2026-02-15 08:00:00",
+                "user@example.com",
+                "$175.00",
+                "#00FFFF",
+            ),
+            _submission_row(
+                "not a timestamp",
+                "user@example.com",
+                "$150.00",
+                None,
+                "",
+            ),
+        ]
+    )
+
+    submissions = _parse_past_submissions_from_grid(grid_response, "user@example.com")
+
+    assert [submission.submitted_at_display for submission in submissions] == [
+        "2026-02-15 08:00:00",
+        "2026-02-01 09:30:00",
+        "2026-01-01 10:00:00",
+        "not a timestamp",
+    ]
+    assert [submission.status for submission in submissions] == [
+        "Pending",
+        "Paid",
+        "In Review",
+        "Submitted",
+    ]
+    assert submissions[0].status_color == "#00FFFF"
+    assert submissions[1].status_color == "#B6D7A8"
+    assert submissions[1].total_reimbursed == "$125.50"
+    assert submissions[3].drive_link == ""
+
+
+def test_parse_past_submissions_defaults_unmapped_colors_to_submitted() -> None:
+    grid_response = _grid_response(
+        [
+            _row(
+                _cell("Timestamp"),
+                _cell("Name"),
+                _cell("Mac Email"),
+                _cell("Address"),
+                _cell("E-transfer Email"),
+                _cell("Team"),
+                _cell("Total Reimbursed"),
+                _cell("Google Drive Link"),
+                _cell("Comments"),
+            ),
+            _submission_row(
+                "2026-01-01",
+                "user@example.com",
+                "$100.00",
+                "#ABCDEF",
+            ),
+        ]
+    )
+
+    submissions = _parse_past_submissions_from_grid(grid_response, "user@example.com")
+
+    assert len(submissions) == 1
+    assert submissions[0].status == "Submitted"
+    assert submissions[0].status_color is None
+
+
+def test_parse_past_submissions_supports_legacy_legend_labels() -> None:
+    grid_response = {
+        "sheets": [
+            _sheet(
+                "Website Responses",
+                [
+                    _row(
+                        _cell("Timestamp"),
+                        _cell("Name"),
+                        _cell("Mac Email"),
+                        _cell("Address"),
+                        _cell("E-transfer Email"),
+                        _cell("Team"),
+                        _cell("Total Reimbursed"),
+                        _cell("Google Drive Link"),
+                        _cell("Comments"),
+                    ),
+                    _submission_row(
+                        "2026-01-01",
+                        "user@example.com",
+                        "$100.00",
+                        "#B6D7A8",
+                    ),
+                ],
+            ),
+            _sheet(
+                "Color Legend",
+                [
+                    _row(_cell("LEGEND (by color code)", "#EDEDED")),
+                    _row(_cell("Approved by Sonya", "#B6D7A8")),
+                ],
+            ),
+        ]
+    }
+
+    submissions = _parse_past_submissions_from_grid(grid_response, "user@example.com")
+
+    assert len(submissions) == 1
+    assert submissions[0].status == "Paid"


### PR DESCRIPTION
## Summary
- add a Past Submissions page backed by Google Sheets history
- derive user-facing status from sheet row colors and the Color Legend tab
- add a Home card for Past Submissions and tests for route/session behavior

## Stacked on
- #288

## Tests
- npm run build:css
- uv run pytest
- uv run ruff check --fix
- uv run ruff format