### PR TITLE
Fix reimbursement edge cases and Drive lookup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ dependencies = [
 
 [dependency-groups]
 dev = [
-    "httpx2>=2.3.0,<2.4.0",
     "pytest>=8.3.0",
     "ruff>=0.15.18",
     "ty>=0.0.29",

--- a/src/data_processing.py
+++ b/src/data_processing.py
@@ -211,7 +211,11 @@ def create_purchase_request(
                 ws[f"E{row}"] = item.unit_price
                 ws[f"F{row}"] = item.total
 
-            ws["F59"] = form.us_subtotal if form.is_usd else form.subtotal_amount
+            ws["F59"] = (
+                form.us_subtotal
+                if form.is_usd
+                else form.subtotal_amount - form.discount_amount
+            )
             ws["F60"] = form.us_additional_fees if form.is_usd else form.hst_gst_amount
             ws["F61"] = form.us_total if form.is_usd else form.shipping_amount
             ws["F62"] = form.total_cad_amount

--- a/src/google_drive.py
+++ b/src/google_drive.py
@@ -22,6 +22,11 @@ DRIVE_SCOPES = ["https://www.googleapis.com/auth/drive"]
 FOLDER_MIME = "application/vnd.google-apps.folder"
 
 
+def _escape_drive_query_literal(value: str) -> str:
+    """Escape a value embedded in a Google Drive query string literal."""
+    return value.replace("\\", "\\\\").replace("'", "\\'")
+
+
 class GoogleDriveClient:
     """Client for interacting with Google Drive API."""
 
@@ -83,9 +88,11 @@ class GoogleDriveClient:
         """Find or create a "Month YYYY" folder inside ``parent_id``."""
         service = self._service()
         name = datetime.now().strftime("%B %Y")
+        escaped_name = _escape_drive_query_literal(name)
+        escaped_parent_id = _escape_drive_query_literal(parent_id)
         query = (
-            f"name='{name}' and mimeType='{FOLDER_MIME}' "
-            f"and '{parent_id}' in parents and trashed=false"
+            f"name='{escaped_name}' and mimeType='{FOLDER_MIME}' "
+            f"and '{escaped_parent_id}' in parents and trashed=false"
         )
         try:
             results = service.files().list(q=query, fields="files(id, name)").execute()
@@ -249,7 +256,12 @@ class GoogleDriveClient:
         except RuntimeError:
             return ""
 
-        query = f"name='{file_name}' and '{folder_id}' in parents and trashed=false"
+        escaped_file_name = _escape_drive_query_literal(file_name)
+        escaped_folder_id = _escape_drive_query_literal(folder_id)
+        query = (
+            f"name='{escaped_file_name}' and '{escaped_folder_id}' in parents "
+            "and trashed=false"
+        )
         try:
             files = (
                 service.files()

--- a/src/routers/dashboard.py
+++ b/src/routers/dashboard.py
@@ -6,6 +6,7 @@ import re
 import shutil
 from dataclasses import dataclass
 from datetime import datetime
+from decimal import ROUND_HALF_UP, Decimal
 from pathlib import Path
 from urllib.parse import urlencode
 
@@ -44,7 +45,8 @@ from src.routers.utils import get_authenticated_user_email, templates
 logger = setup_logger(__name__)
 
 router = APIRouter(tags=["dashboard"])
-MIN_TOTAL_CAD_AMOUNT = 100.0
+CAD_CENT = Decimal("0.01")
+MIN_TOTAL_CAD_AMOUNT = Decimal("100.00")
 SESSIONS_ROOT = Path("sessions").resolve()
 ITEM_FIELD_PATTERN = re.compile(
     r"^item_(?:name|usage|quantity|price)_(?P<form>\d+)_(?P<item>\d+)$"
@@ -92,6 +94,11 @@ def _safe_filename_component(value: str) -> str:
 
 def _dashboard_url(**params: str) -> str:
     return "/dashboard" if not params else f"/dashboard?{urlencode(params)}"
+
+
+def _round_cad_amount(value: float) -> Decimal:
+    """Round a CAD amount to cents using the same half-up rule as the frontend."""
+    return Decimal(str(value)).quantize(CAD_CENT, rounding=ROUND_HALF_UP)
 
 
 def _posted_item_numbers(form_data: FormData, form_num: int) -> set[int]:
@@ -532,7 +539,10 @@ async def _submit_all_requests(
             status_code=303,
         )
 
-    total_cad_amount = sum(form.total_cad_amount for form in submitted_forms)
+    total_cad_amount = sum(
+        (_round_cad_amount(form.total_cad_amount) for form in submitted_forms),
+        start=Decimal("0.00"),
+    )
     if total_cad_amount < MIN_TOTAL_CAD_AMOUNT:
         logger.warning(f"Submission below minimum CAD amount: ${total_cad_amount:.2f}")
         await _cleanup_session_folder(session_folder)

--- a/src/static/js/dashboard.js
+++ b/src/static/js/dashboard.js
@@ -82,7 +82,7 @@ function formatMoneyFromPreciseAmount(scaledValue) {
         preciseDecimalPlaces,
         moneyDecimalPlaces
     );
-    return formatScaledAmount(cents, moneyDecimalPlaces);
+    return formatMoneyCents(cents);
 }
 
 function parseMoneyCents(value) {
@@ -90,7 +90,16 @@ function parseMoneyCents(value) {
 }
 
 function formatMoneyCents(cents) {
-    return formatScaledAmount(cents, moneyDecimalPlaces);
+    const scale = decimalScale(moneyDecimalPlaces);
+    const isNegative = cents < 0n;
+    const absoluteValue = isNegative ? -cents : cents;
+    const wholePart = absoluteValue / scale;
+    const fractionPart = String(absoluteValue % scale).padStart(
+        moneyDecimalPlaces,
+        '0'
+    );
+    const sign = isNegative ? '-' : '';
+    return `${sign}${wholePart}.${fractionPart}`;
 }
 
 function formatMoneyInput(input) {

--- a/tests/api/test_submit_all_requests_pipeline.py
+++ b/tests/api/test_submit_all_requests_pipeline.py
@@ -501,10 +501,10 @@ def test_submit_all_requests_rejects_total_below_minimum(monkeypatch, tmp_path) 
     response = client.post(
         "/submit-all-requests",
         data=_valid_cad_data(
-            subtotal_amount_1="99.99",
-            total_cad_amount_1="99.99",
-            item_price_1_1="99.99",
-            item_total_1_1="99.99",
+            subtotal_amount_1="99.994",
+            total_cad_amount_1="99.994",
+            item_price_1_1="99.994",
+            item_total_1_1="99.994",
         ),
         files=_invoice_file(),
     )
@@ -513,3 +513,67 @@ def test_submit_all_requests_rejects_total_below_minimum(monkeypatch, tmp_path) 
     assert response.headers["location"] == "/dashboard?error=below_minimum"
     assert "purchase_request" not in calls
     assert not session_folder.exists()
+
+
+def test_submit_all_requests_accepts_total_that_rounds_to_minimum(
+    monkeypatch, tmp_path
+) -> None:
+    import src.routers.dashboard as dashboard_module
+
+    _patch_session_folder(monkeypatch, dashboard_module, tmp_path, "session-rounded")
+    _patch_user_and_profile_files(monkeypatch, dashboard_module, _make_user())
+    calls = _patch_external_clients(monkeypatch, dashboard_module)
+
+    client = _make_test_client()
+    response = client.post(
+        "/submit-all-requests",
+        data=_valid_cad_data(
+            subtotal_amount_1="99.995",
+            total_cad_amount_1="99.995",
+            item_price_1_1="99.995",
+            item_total_1_1="99.995",
+        ),
+        files=_invoice_file(),
+    )
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/success"
+    assert "purchase_request" in calls
+
+
+def test_submit_all_requests_sums_individually_rounded_invoice_totals(
+    monkeypatch, tmp_path
+) -> None:
+    import src.routers.dashboard as dashboard_module
+
+    _patch_session_folder(
+        monkeypatch, dashboard_module, tmp_path, "session-rounded-invoices"
+    )
+    _patch_user_and_profile_files(monkeypatch, dashboard_module, _make_user())
+    calls = _patch_external_clients(monkeypatch, dashboard_module)
+
+    data = _valid_cad_data_for_form(
+        1,
+        subtotal_amount_1="49.995",
+        total_cad_amount_1="49.995",
+        item_price_1_1="49.995",
+        item_total_1_1="49.995",
+    )
+    data.update(
+        _valid_cad_data_for_form(
+            2,
+            subtotal_amount_2="49.995",
+            total_cad_amount_2="49.995",
+            item_price_2_1="49.995",
+            item_total_2_1="49.995",
+        )
+    )
+    files = _invoice_file(1)
+    files.update(_invoice_file(2))
+
+    client = _make_test_client()
+    response = client.post("/submit-all-requests", data=data, files=files)
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/success"
+    assert len(calls["purchase_request"][1]) == 2

--- a/tests/unit/test_data_processing.py
+++ b/tests/unit/test_data_processing.py
@@ -169,6 +169,7 @@ def test_create_purchase_request_supports_fifty_item_template_rows(
             _make_form(
                 items=items,
                 subtotal_amount=125.0,
+                discount_amount=20.0,
                 hst_gst_amount=16.25,
                 shipping_amount=10.0,
                 total_cad_amount=151.25,
@@ -190,7 +191,7 @@ def test_create_purchase_request_supports_fifty_item_template_rows(
         assert _as_date(ws["B1"].value) == date(2024, 1, 15)
         assert ws["B1"].number_format == "yyyy-mm-dd"
         assert ws["B67"].value == "123 Main St"
-        assert ws["F59"].value == 125.0
+        assert ws["F59"].value == 105.0
         assert ws["F60"].value == 16.25
         assert ws["F61"].value == 10.0
         assert ws["F62"].value == 151.25
@@ -229,11 +230,15 @@ def test_create_purchase_request_deletes_unsubmitted_receipt_sheets(
                 form_number=1,
                 vendor_name="First Vendor",
                 items=_make_items(1),
+                subtotal_amount=125.0,
+                discount_amount=20.0,
             ),
             _make_form(
                 form_number=3,
                 vendor_name="Third Vendor",
                 items=_make_items(2),
+                is_usd=True,
+                us_subtotal=80.0,
             ),
         ],
         str(tmp_path),
@@ -243,7 +248,9 @@ def test_create_purchase_request_deletes_unsubmitted_receipt_sheets(
     try:
         assert wb.sheetnames == ["Receipt1", "Receipt3"]
         assert wb["Receipt1"]["B7"].value == "First Vendor"
+        assert wb["Receipt1"]["F59"].value == 105.0
         assert wb["Receipt3"]["B7"].value == "Third Vendor"
+        assert wb["Receipt3"]["F59"].value == 80.0
     finally:
         wb.close()
 

--- a/tests/unit/test_google_drive.py
+++ b/tests/unit/test_google_drive.py
@@ -1,0 +1,38 @@
+from src.google_drive import GoogleDriveClient
+
+
+class FakeListRequest:
+    def execute(self) -> dict[str, list[dict[str, str]]]:
+        return {"files": [{"id": "file-id", "name": "receipt.xlsx"}]}
+
+
+class FakeFilesResource:
+    def __init__(self) -> None:
+        self.query = ""
+
+    def list(self, *, q: str, fields: str) -> FakeListRequest:
+        self.query = q
+        assert fields == "files(id, name)"
+        return FakeListRequest()
+
+
+class FakeDriveService:
+    def __init__(self) -> None:
+        self.files_resource = FakeFilesResource()
+
+    def files(self) -> FakeFilesResource:
+        return self.files_resource
+
+
+def test_find_file_escapes_apostrophes_and_backslashes_in_query() -> None:
+    service = FakeDriveService()
+    client = GoogleDriveClient()
+    client.service = service
+
+    file_id = client.find_file_in_folder("folder'id\\archive", "O'Brian\\receipt.xlsx")
+
+    assert file_id == "file-id"
+    assert service.files_resource.query == (
+        "name='O\\'Brian\\\\receipt.xlsx' and "
+        "'folder\\'id\\\\archive' in parents and trashed=false"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -393,19 +393,6 @@ wheels = [
 ]
 
 [[package]]
-name = "httpcore2"
-version = "2.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "h11" },
-    { name = "truststore" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e6/34/18f1c596e677962f040284246f393b10a1f8ce440b3a7e69c637d0f1c7ad/httpcore2-2.3.0.tar.gz", hash = "sha256:07327e251560960eea8e969d92d4c6a325feb13cca39e25340731336c3baf924", size = 64300, upload-time = "2026-06-01T13:15:02.998Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/dd/3357218c69360d1cecc196c230c9a1d5c9afd5dba362056e23e60a5e64e5/httpcore2-2.3.0-py3-none-any.whl", hash = "sha256:477e9e334f74e5240dcac002e890580f36a57d40ff0fb14cc9655731d23b8415", size = 80024, upload-time = "2026-06-01T13:15:00.001Z" },
-]
-
-[[package]]
 name = "httplib2"
 version = "0.31.2"
 source = { registry = "https://pypi.org/simple" }
@@ -445,21 +432,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
-]
-
-[[package]]
-name = "httpx2"
-version = "2.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "httpcore2" },
-    { name = "idna" },
-    { name = "truststore" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9f/9a/cca0b9145f13d8ae34b885ae28d403a1469a433abc78e0f94f4ce94e650b/httpx2-2.3.0.tar.gz", hash = "sha256:227e7c41d95a76d4077a52640564132777215fc3394e07b66a3116c33d668fa9", size = 81115, upload-time = "2026-06-01T13:15:04.324Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/ce/ae2911859847f9ba1d6b23027e53481cbeb50b93234f355a968d300ca2cb/httpx2-2.3.0-py3-none-any.whl", hash = "sha256:6f393663bdf6dbe7fe90118e3eb5b2bd024a675cae0390ac08cec9198812d8b7", size = 74538, upload-time = "2026-06-01T13:15:01.566Z" },
 ]
 
 [[package]]
@@ -695,7 +667,6 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "httpx2" },
     { name = "pytest" },
     { name = "ruff" },
     { name = "ty" },
@@ -719,7 +690,6 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "httpx2", specifier = ">=2.3.0,<2.4.0" },
     { name = "pytest", specifier = ">=8.3.0" },
     { name = "ruff", specifier = ">=0.15.18" },
     { name = "ty", specifier = ">=0.0.29" },
@@ -1058,15 +1028,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
-]
-
-[[package]]
-name = "truststore"
-version = "0.10.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- escape apostrophes and backslashes in Google Drive query literals
- display monetary summaries with exactly two decimals
- round each invoice to cents before enforcing the $100 CAD minimum
- apply CAD discounts to purchase request cell F59 while preserving USD behavior
- remove the unused `httpx2` development dependency

## Testing
- `uv sync --frozen`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run ty check src tests`
- `uv run pytest` (47 passed, 3 skipped)
- Docker image build and browser smoke test

Closes #290
Closes #291
Closes #292
Closes #293
Closes #294