### PR TITLE
Add environment configuration example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,10 +27,5 @@ GOOGLE_SETTINGS__CLIENT_X509_CERT_URL=https://www.googleapis.com/robot/v1/metada
 SENTRY_DSN=
 SENTRY_RELEASE=
 
-# Runtime overrides. Docker Compose currently sets HOST and PORT itself.
-HOST=0.0.0.0
-PORT=8000
-DEBUG=false
-
 # Optional Docker image override used by docker-compose.yml.
 APP_IMAGE=purchase-request-site:latest

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,36 @@
+# Mandatory
+# Copy this file to .env and replace every placeholder before starting the app.
+
+# Use "testing" for local/test behavior or "production" for deployment.
+ENVIRONMENT=testing
+
+# PostgreSQL connection string. Required in production.
+DATABASE_URL=postgresql://username:password@hostname:5432/database_name
+
+# Google Sheets and Drive destinations.
+GOOGLE_SHEET_ID=your-google-sheet-id
+GOOGLE_DRIVE_FOLDER_ID=your-google-drive-folder-id
+
+# Google service-account credentials. Keep the private key on one line with
+# literal \n sequences; the application converts them to newlines at runtime.
+GOOGLE_SETTINGS__PROJECT_ID=your-google-cloud-project-id
+GOOGLE_SETTINGS__PRIVATE_KEY_ID=your-service-account-private-key-id
+GOOGLE_SETTINGS__PRIVATE_KEY="your-service-account-private-key-with-literal-backslash-n-sequences"
+GOOGLE_SETTINGS__CLIENT_EMAIL=your-service-account@your-project.iam.gserviceaccount.com
+GOOGLE_SETTINGS__CLIENT_ID=your-service-account-client-id
+GOOGLE_SETTINGS__CLIENT_X509_CERT_URL=https://www.googleapis.com/robot/v1/metadata/x509/your-service-account%40your-project.iam.gserviceaccount.com
+
+
+# Optional
+
+# Error monitoring. Leave blank to disable Sentry delivery.
+SENTRY_DSN=
+SENTRY_RELEASE=
+
+# Runtime overrides. Docker Compose currently sets HOST and PORT itself.
+HOST=0.0.0.0
+PORT=8000
+DEBUG=false
+
+# Optional Docker image override used by docker-compose.yml.
+APP_IMAGE=purchase-request-site:latest

--- a/src/core/settings.py
+++ b/src/core/settings.py
@@ -30,7 +30,7 @@ class Settings(BaseSettings):
     sentry_release: str | None = Field(default=None, alias="SENTRY_RELEASE")
     host: str = Field(default="0.0.0.0", alias="HOST")
     port: int = Field(default=8000, alias="PORT")
-    debug: bool = Field(default=True, alias="DEBUG")
+    debug: bool = Field(default=False, alias="DEBUG")
     database_url: str = Field(
         default="",
         alias="DATABASE_URL",

--- a/src/core/settings.py
+++ b/src/core/settings.py
@@ -30,7 +30,7 @@ class Settings(BaseSettings):
     sentry_release: str | None = Field(default=None, alias="SENTRY_RELEASE")
     host: str = Field(default="0.0.0.0", alias="HOST")
     port: int = Field(default=8000, alias="PORT")
-    debug: bool = Field(default=False, alias="DEBUG")
+    debug: bool = Field(default=True, alias="DEBUG")
     database_url: str = Field(
         default="",
         alias="DATABASE_URL",


### PR DESCRIPTION
## Summary

- add a copy-ready `.env.example`
- separate mandatory configuration from optional settings
- document PostgreSQL, Google service-account, Sentry, and Docker variables
- use placeholders only, including guidance for newline-escaped Google private keys

## Why

The application reads several required environment variables, but the repository did not provide a safe reference file showing which values are needed or how they should be formatted.

## Impact

Developers and deployers can copy `.env.example` to `.env` and replace the placeholders without inspecting the settings implementation or risking committing real credentials.

## Validation

- `git diff --check -- .env.example`
- sourced `.env.example` and verified mandatory placeholders are populated
- pre-commit hooks passed, including gitleaks
- `uv run ruff check src/core/settings.py`
- `uv run ruff format --check src/core/settings.py`
- `uv run ty check src/core/settings.py`
- `uv run pytest tests/unit` (16 passed)
