### PR TITLE
Avoid blocking work in async handlers

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -16,6 +16,7 @@ from sentry_sdk.integrations.logging import LoggingIntegration
 from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
 from sentry_sdk.types import Event, Hint
 from slowapi.errors import RateLimitExceeded
+from starlette.concurrency import run_in_threadpool
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.middleware.sessions import SessionMiddleware
 
@@ -143,35 +144,35 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     os.makedirs("sessions", exist_ok=True)
     configure_sentry()
     configure_uvicorn_access_log_filter()
-    init_database()
+    await run_in_threadpool(init_database)
     yield
 
 
-async def handle_exceed_limit(request: Request, exc: Exception):
+def handle_exceed_limit(request: Request, exc: Exception):
     """Handle rate limit exceeded errors by redirecting to login with error message"""
     if not isinstance(exc, RateLimitExceeded):
         raise exc
     return RedirectResponse(url="/login?error=ratelimit", status_code=303)
 
 
-async def home():
+def home():
     """Redirect home page to login"""
     return RedirectResponse(url="/login", status_code=303)
 
 
-async def health_check():
+def health_check():
     """Health check endpoint for Docker health monitoring"""
     return {"status": "healthy", "timestamp": datetime.now().isoformat()}
 
 
-async def auth_redirect_handler(request: Request, exc: Exception):
+def auth_redirect_handler(request: Request, exc: Exception):
     """Redirect unauthenticated requests to the login page (or other target)."""
     if not isinstance(exc, AuthRedirect):
         raise exc
     return RedirectResponse(url=exc.location, status_code=303)
 
 
-async def http_exception_handler(request: Request, exc: Exception):
+def http_exception_handler(request: Request, exc: Exception):
     if not isinstance(exc, StarletteHTTPException):
         raise exc
     if exc.status_code == 404:
@@ -189,7 +190,7 @@ async def http_exception_handler(request: Request, exc: Exception):
     )
 
 
-async def generic_exception_handler(request: Request, exc: Exception):
+def generic_exception_handler(request: Request, exc: Exception):
     if request.url.path.startswith(HEALTH_PATH_PREFIX):
         return JSONResponse(status_code=500, content={"status": "unhealthy"})
     logger.error(f"Unhandled exception: {exc}", exc_info=True)

--- a/src/routers/auth.py
+++ b/src/routers/auth.py
@@ -19,7 +19,7 @@ router = APIRouter(tags=["authentication"])
 
 
 @router.get("/login")
-async def login_page(request: Request, error: str | None = None):
+def login_page(request: Request, error: str | None = None):
     """Display login page"""
 
     error_messages = {
@@ -70,7 +70,7 @@ def login(
 
 
 @router.get("/logout")
-async def logout(request: Request):
+def logout(request: Request):
     """Handle user logout"""
     request.session.clear()
     logger.info("🔓 User logged out")

--- a/src/routers/success.py
+++ b/src/routers/success.py
@@ -15,7 +15,7 @@ router = APIRouter(tags=["success"])
 
 
 @router.get("/success")
-async def success_page(
+def success_page(
     request: Request,
     _: str = Depends(get_authenticated_user_email),
 ):


### PR DESCRIPTION
## Summary

- offload synchronous database initialization from the FastAPI lifespan event loop
- make routes and exception handlers with no asynchronous work synchronous
- let FastAPI and Starlette execute template rendering, logging, and other synchronous handler work in their thread pool

## Why

Several handlers were declared `async` while doing only synchronous work, and database initialization ran directly inside the asynchronous lifespan hook. This could block the event loop during startup and request handling.

## Impact

No API or response behavior changes. Startup ordering is preserved, while synchronous work now runs through the framework's synchronous execution path.

## Validation

- `uv sync --frozen`
- `uv run ruff check src/main.py src/routers/auth.py src/routers/success.py`
- `uv run ruff format --check src/main.py src/routers/auth.py src/routers/success.py`
- `uv run ty check src/main.py src/routers/auth.py src/routers/success.py`
- `uv run pytest --ignore=tests/integration/test_google_connections.py` — 47 passed, 1 skipped

The live Google connection tests were excluded because the isolated worktree does not contain deployment credentials.
