### PR TITLE
Prevent invalid profile submissions

### DIFF
--- a/src/routers/profile.py
+++ b/src/routers/profile.py
@@ -128,12 +128,13 @@ def edit_profile_post(
         redirect_url = "/home?updated=true"
         return RedirectResponse(url=redirect_url, status_code=303)
 
+    except ValueError as exc:
+        logger.warning(f"Profile update rejected for {authenticated_email}: {exc}")
     except Exception:
         logger.exception(f"Error updating profile for {authenticated_email}")
-        db.rollback()
 
-        # Redirect back to edit form with error
-        return RedirectResponse(
-            url="/edit-profile?error=update_failed",
-            status_code=303,
-        )
+    db.rollback()
+    return RedirectResponse(
+        url="/edit-profile?error=update_failed",
+        status_code=303,
+    )

--- a/src/templates/edit_profile.html
+++ b/src/templates/edit_profile.html
@@ -25,7 +25,7 @@
             </div>
         </header>
 
-        <form method="post" novalidate enctype="multipart/form-data" class="app-card form-card">
+        <form method="post" enctype="multipart/form-data" class="app-card form-card">
             <div class="form-grid">
                 <div class="field">
                     <label for="name" class="field-label">Full Name <span class="required-mark">*</span></label>


### PR DESCRIPTION
## What changed

- Re-enable native browser validation on the profile form so required fields and the required void-cheque upload are checked before submission.
- Treat expected profile validation failures (`ValueError`) as warnings instead of Sentry error events.
- Preserve rollback and the existing user-facing error redirect for rejected submissions.

## Why

A profile update produced a generic Sentry error immediately after form submission. The most likely cause was a user without a stored void cheque submitting the form without selecting one. The form marked that upload as required, but `novalidate` disabled the browser check, allowing the server-side `Void cheque PDF is required` validation to fire and be reported as an application error.

## Impact

Users receive immediate browser feedback for missing or invalid required fields, while expected validation failures no longer generate noisy Sentry error events. Unexpected exceptions are still reported as errors.

## Verification

- `uv run ruff check --fix src/routers/profile.py`
- `uv run pytest` - 54 passed, 3 skipped
- Pre-commit hooks: protect-main, gitleaks, and Ruff passed
