### PR TITLE
Allow production login sessions over HTTP

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -128,7 +128,6 @@ def create_app() -> FastAPI:
     application.add_middleware(
         SessionMiddleware,
         secret_key=session_secret,
-        https_only=settings.is_production,
         same_site="lax",
         max_age=60 * 60 * 24,
     )

--- a/tests/api/test_app_routes.py
+++ b/tests/api/test_app_routes.py
@@ -13,7 +13,7 @@ def test_sessions_directory_is_not_mounted() -> None:
     assert "/sessions" not in mounted_paths
 
 
-def test_production_session_uses_configured_secret_and_secure_cookie(
+def test_production_session_uses_configured_secret_and_http_cookie(
     monkeypatch,
 ) -> None:
     import src.main as main_module
@@ -33,5 +33,5 @@ def test_production_session_uses_configured_secret_and_secure_cookie(
     )
 
     assert middleware.kwargs["secret_key"] == "stable-session-secret"
-    assert middleware.kwargs["https_only"] is True
+    assert middleware.kwargs.get("https_only", False) is False
     assert middleware.kwargs["same_site"] == "lax"


### PR DESCRIPTION
## Summary

- stop marking production session cookies as HTTPS-only
- keep the configured session secret, same-site policy, and 24-hour lifetime
- update the existing middleware test for the HTTP deployment

## Why

Production currently runs at `http://137.184.172.99:8000`. Browsers reject secure cookies on that URL, so a successful login loses its session during the redirect to `/home` and returns to `/login`.

## Verification

- `uv run pytest` (67 passed, 3 skipped)
- `uv run ruff check`
- `uv run ty check`