### PR TITLE
Restore Sentry logs and allow HTTP sessions

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -129,7 +129,6 @@ def create_app() -> FastAPI:
     application.add_middleware(
         SessionMiddleware,
         secret_key=session_secret,
-        https_only=settings.is_production,
         same_site="lax",
         max_age=60 * 60 * 24,
     )

--- a/src/main.py
+++ b/src/main.py
@@ -44,6 +44,7 @@ def configure_sentry() -> None:
         ],
         environment=settings.environment,
         release=settings.sentry_release,
+        enable_logs=True,
         sample_rate=1.0,
         traces_sample_rate=settings.sentry_traces_sample_rate,
     )

--- a/tests/api/test_app_routes.py
+++ b/tests/api/test_app_routes.py
@@ -13,7 +13,7 @@ def test_sessions_directory_is_not_mounted() -> None:
     assert "/sessions" not in mounted_paths
 
 
-def test_production_session_uses_configured_secret_and_secure_cookie(
+def test_production_session_uses_configured_secret_and_http_cookie(
     monkeypatch,
 ) -> None:
     import src.main as main_module
@@ -33,5 +33,5 @@ def test_production_session_uses_configured_secret_and_secure_cookie(
     )
 
     assert middleware.kwargs["secret_key"] == "stable-session-secret"
-    assert middleware.kwargs["https_only"] is True
+    assert middleware.kwargs.get("https_only", False) is False
     assert middleware.kwargs["same_site"] == "lax"


### PR DESCRIPTION
## Summary

- restore standalone Sentry Logs for the existing Python logging integration
- allow session cookies over the current HTTP production deployment

The session change fixes the successful-login redirect loop at `http://137.184.172.99:8000`. The logging change restores searchable INFO and warning logs without bringing back custom middleware.

## Verification

- `uv run pytest` (67 passed, 3 skipped)
- `uv run ruff check`
- `uv run ty check`